### PR TITLE
<FEAT> 글로벌 에러 핸들링 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.2.0'
+
+	// jackson
+	// support java 8 time api
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -22,16 +22,20 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'org.springframework.session:spring-session-data-redis'
 	implementation 'org.testng:testng:7.1.0'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
+
+	// db
+	implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+	implementation 'org.springframework.session:spring-session-data-redis'
+	implementation 'io.r2dbc:r2dbc-mariadb'
+	implementation 'org.mariadb:r2dbc-mariadb'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
 	// netty
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.session:spring-session-data-redis'
+	implementation 'org.testng:testng:7.1.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.session:spring-session-data-redis'
 	implementation 'org.testng:testng:7.1.0'
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'org.springframework.session:spring-session-data-redis'
-	implementation 'io.r2dbc:r2dbc-mariadb'
-	implementation 'org.mariadb:r2dbc-mariadb'
+	implementation 'org.mariadb:r2dbc-mariadb:1.1.4'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
 	// netty

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.session:spring-session-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
@@ -32,8 +33,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
 
+	// netty
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+
 	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.0.2'
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/instream/tenant/common/Swagger3Config.java
+++ b/src/main/java/com/instream/tenant/common/Swagger3Config.java
@@ -1,0 +1,32 @@
+package com.instream.tenant.common;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.utils.SpringDocUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpHeaders;
+
+@Configuration
+public class Swagger3Config {
+    private final Environment env;
+
+    @Autowired
+    public Swagger3Config(Environment env) {
+        this.env = env;
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info().title("TENANT API").description("TENANT API 명세서입니다.");
+
+        return new OpenAPI().addServersItem(new Server().url(env.getProperty("server.servlet.context-path"))).info(info);
+    }
+}

--- a/src/main/java/com/instream/tenant/common/Swagger3Config.java
+++ b/src/main/java/com/instream/tenant/common/Swagger3Config.java
@@ -27,6 +27,6 @@ public class Swagger3Config {
     public OpenAPI openAPI() {
         Info info = new Info().title("TENANT API").description("TENANT API 명세서입니다.");
 
-        return new OpenAPI().addServersItem(new Server().url(env.getProperty("server.servlet.context-path"))).info(info);
+        return new OpenAPI().addServersItem(new Server().url(env.getProperty("spring.webflux.base-path"))).info(info);
     }
 }

--- a/src/main/java/com/instream/tenant/core/config/R2dbcConfig.java
+++ b/src/main/java/com/instream/tenant/core/config/R2dbcConfig.java
@@ -1,23 +1,26 @@
 package com.instream.tenant.core.config;
 
+import com.instream.tenant.domain.common.infra.converter.uuid.UUIDReadConverter;
+import com.instream.tenant.domain.common.infra.converter.uuid.UUIDWriteConverter;
 import com.instream.tenant.domain.host.infra.converter.StatusReadConverter;
 import com.instream.tenant.domain.host.infra.converter.StatusWriteConverter;
-import io.r2dbc.spi.ConnectionFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
 import org.springframework.data.r2dbc.convert.R2dbcCustomConversions;
 import org.springframework.data.r2dbc.dialect.MySqlDialect;
-import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
 
 import java.util.List;
 
 @Configuration
 public class R2dbcConfig {
+    private final List<Converter<?, ?>> converters = List.of(
+            new StatusWriteConverter(), new StatusReadConverter(),
+            new UUIDReadConverter(), new UUIDWriteConverter()
+    );
+
     @Bean
     public R2dbcCustomConversions r2dbcCustomConversions() {
-        List<Converter<?, ?>> converters = List.of(new StatusWriteConverter(), new StatusReadConverter());
         return R2dbcCustomConversions.of(MySqlDialect.INSTANCE, converters);
     }
 }

--- a/src/main/java/com/instream/tenant/core/config/R2dbcConfig.java
+++ b/src/main/java/com/instream/tenant/core/config/R2dbcConfig.java
@@ -1,0 +1,23 @@
+package com.instream.tenant.core.config;
+
+import com.instream.tenant.domain.host.infra.converter.StatusReadConverter;
+import com.instream.tenant.domain.host.infra.converter.StatusWriteConverter;
+import io.r2dbc.spi.ConnectionFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
+import org.springframework.data.r2dbc.convert.R2dbcCustomConversions;
+import org.springframework.data.r2dbc.dialect.MySqlDialect;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+
+import java.util.List;
+
+@Configuration
+public class R2dbcConfig {
+    @Bean
+    public R2dbcCustomConversions r2dbcCustomConversions() {
+        List<Converter<?, ?>> converters = List.of(new StatusWriteConverter(), new StatusReadConverter());
+        return R2dbcCustomConversions.of(MySqlDialect.INSTANCE, converters);
+    }
+}

--- a/src/main/java/com/instream/tenant/core/config/Swagger3Config.java
+++ b/src/main/java/com/instream/tenant/core/config/Swagger3Config.java
@@ -1,4 +1,4 @@
-package com.instream.tenant.common;
+package com.instream.tenant.core.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/src/main/java/com/instream/tenant/core/config/WebConfig.java
+++ b/src/main/java/com/instream/tenant/core/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.instream.tenant.core.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+@Configuration
+public class WebConfig implements WebFluxConfigurer {
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+
+    @Override
+    public void configureHttpMessageCodecs(ServerCodecConfigurer configurer) {
+        configurer.defaultCodecs().jackson2JsonEncoder(new Jackson2JsonEncoder(objectMapper()));
+        configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper()));
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/common/infra/converter/status/StatusReadConverter.java
+++ b/src/main/java/com/instream/tenant/domain/common/infra/converter/status/StatusReadConverter.java
@@ -1,0 +1,13 @@
+package com.instream.tenant.domain.common.infra.converter.status;
+
+import com.instream.tenant.domain.common.infra.enums.Status;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+
+@ReadingConverter
+public class StatusReadConverter implements Converter<String, Status> {
+    @Override
+    public Status convert(String source) {
+        return Status.fromCode(source);
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/common/infra/converter/status/StatusWriteConverter.java
+++ b/src/main/java/com/instream/tenant/domain/common/infra/converter/status/StatusWriteConverter.java
@@ -1,0 +1,14 @@
+package com.instream.tenant.domain.common.infra.converter.status;
+
+import com.instream.tenant.domain.common.infra.enums.Status;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+
+@WritingConverter
+public class StatusWriteConverter implements Converter<Status, String> {
+    @Override
+    public String convert(Status source) {
+        return source.getCode();
+    }
+}
+

--- a/src/main/java/com/instream/tenant/domain/common/infra/converter/uuid/UUIDReadConverter.java
+++ b/src/main/java/com/instream/tenant/domain/common/infra/converter/uuid/UUIDReadConverter.java
@@ -1,0 +1,18 @@
+package com.instream.tenant.domain.common.infra.converter.uuid;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+@ReadingConverter
+public  class UUIDReadConverter implements Converter<byte[], UUID> {
+    @Override
+    public UUID convert(final byte[] source) {
+        final var bb = ByteBuffer.wrap(source);
+        final var firstLong = bb.getLong();
+        final var secondLong = bb.getLong();
+        return new UUID(firstLong, secondLong);
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/common/infra/converter/uuid/UUIDWriteConverter.java
+++ b/src/main/java/com/instream/tenant/domain/common/infra/converter/uuid/UUIDWriteConverter.java
@@ -1,0 +1,19 @@
+package com.instream.tenant.domain.common.infra.converter.uuid;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+@WritingConverter
+public  class UUIDWriteConverter implements Converter<UUID, byte[]> {
+    @Override
+    public byte[] convert(final UUID source) {
+        final var bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(source.getMostSignificantBits());
+        bb.putLong(source.getLeastSignificantBits());
+        return bb.array();
+    }
+}
+

--- a/src/main/java/com/instream/tenant/domain/common/infra/enums/Status.java
+++ b/src/main/java/com/instream/tenant/domain/common/infra/enums/Status.java
@@ -1,0 +1,31 @@
+package com.instream.tenant.domain.common.infra.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum Status {
+    USE("N"),
+    DELETED("Y");
+
+    private final String code;
+
+    Status(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String getCode() {
+        return code;
+    }
+
+    @JsonCreator
+    public static Status fromCode(String code) {
+        return Arrays.stream(Status.values())
+                .filter(v -> v.getCode().equals(code))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException(String.format("상태에 %s가 존재하지 않습니다.", code)));
+    }
+}
+

--- a/src/main/java/com/instream/tenant/domain/error/domain/exception/RestApiException.java
+++ b/src/main/java/com/instream/tenant/domain/error/domain/exception/RestApiException.java
@@ -1,0 +1,13 @@
+package com.instream.tenant.domain.error.domain.exception;
+
+import com.instream.tenant.domain.error.infra.enums.HttpErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@ToString
+public class RestApiException extends RuntimeException {
+    private final HttpErrorCode httpErrorCode;
+}

--- a/src/main/java/com/instream/tenant/domain/error/domain/response/ErrorResponse.java
+++ b/src/main/java/com/instream/tenant/domain/error/domain/response/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.instream.tenant.domain.error.domain.response;
+
+import lombok.Builder;
+
+public record ErrorResponse(
+        String code,
+        String message
+) {
+    @Builder
+    public ErrorResponse {
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/error/handler/GlobalErrorWebExceptionHandler.java
+++ b/src/main/java/com/instream/tenant/domain/error/handler/GlobalErrorWebExceptionHandler.java
@@ -1,0 +1,69 @@
+package com.instream.tenant.domain.error.handler;
+
+import com.instream.tenant.domain.error.domain.exception.RestApiException;
+import com.instream.tenant.domain.error.domain.response.ErrorResponse;
+import com.instream.tenant.domain.error.infra.enums.CommonHttpErrorCode;
+import com.instream.tenant.domain.error.infra.enums.HttpErrorCode;
+import org.reactivestreams.Publisher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.codec.EncodingException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@Order(-2) // webflux default @Order(-1)
+public class GlobalErrorWebExceptionHandler implements ErrorWebExceptionHandler {
+    private List<HttpMessageWriter<?>> messageWriters;
+
+    @Autowired
+    public GlobalErrorWebExceptionHandler(ServerCodecConfigurer serverCodecConfigurer) {
+        this.messageWriters = serverCodecConfigurer.getWriters();
+    }
+
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+        if (ex instanceof RestApiException restApiException) {
+            return writeResponse(restApiException.getHttpErrorCode(), exchange);
+        }
+        if (ex instanceof RestClientException) {
+            return writeResponse(CommonHttpErrorCode.SERVICE_UNAVAILABLE, exchange);
+        }
+
+        return writeResponse(CommonHttpErrorCode.INTERNAL_SERVER_ERROR, exchange);
+    }
+
+    private Mono<Void> writeResponse(HttpErrorCode httpErrorCode, ServerWebExchange exchange) {
+        return Mono.defer(() -> {
+            ErrorResponse errorResponse = makeErrorResponse(httpErrorCode);
+            ResolvableType elementType = ResolvableType.forInstance(errorResponse);
+            @SuppressWarnings("unchecked")
+            HttpMessageWriter<ErrorResponse> messageWriter = (HttpMessageWriter<ErrorResponse>) this.messageWriters.stream()
+                    .filter(writer -> writer.canWrite(elementType, MediaType.APPLICATION_JSON))
+                    .findFirst()
+                    .orElseThrow(() -> new EncodingException("No suitable HttpMessageWriter found"));
+
+            exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+            exchange.getResponse().setStatusCode(httpErrorCode.getHttpStatus());
+
+            return messageWriter.write(Mono.just(errorResponse), elementType, MediaType.APPLICATION_JSON, exchange.getResponse(), Collections.emptyMap());
+        });
+    }
+
+
+    private ErrorResponse makeErrorResponse(HttpErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/error/infra/enums/CommonHttpErrorCode.java
+++ b/src/main/java/com/instream/tenant/domain/error/infra/enums/CommonHttpErrorCode.java
@@ -1,0 +1,22 @@
+package com.instream.tenant.domain.error.infra.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonHttpErrorCode implements HttpErrorCode {
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 에러가 발생했습니다."),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "해당 서비스가 이용 불가능합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/error/infra/enums/HttpErrorCode.java
+++ b/src/main/java/com/instream/tenant/domain/error/infra/enums/HttpErrorCode.java
@@ -1,0 +1,12 @@
+package com.instream.tenant.domain.error.infra.enums;
+
+import org.springframework.http.HttpStatus;
+
+public interface HttpErrorCode {
+
+    HttpStatus getHttpStatus();
+
+    String getCode();
+
+    String getMessage();
+}

--- a/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
@@ -3,17 +3,29 @@ package com.instream.tenant.domain.host.config;
 import com.instream.tenant.domain.host.router.HostRouterHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
+import java.util.function.Supplier;
+
 import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
+
 
 @Configuration
 public class HostRouterConfig {
     @Bean
     public RouterFunction<ServerResponse> routes(HostRouterHandler hostRouterHandler) {
-        return route().GET("/hello", hostRouterHandler::hello, ops -> ops
-                .operationId("123")
+        return route().nest(RequestPredicates.path("/v1"),
+                routerFunctionSupplier(hostRouterHandler),
+                ops -> ops.operationId("123")
         ).build();
+    }
+
+    private Supplier<RouterFunction<ServerResponse>> routerFunctionSupplier(HostRouterHandler hostRouterHandler) {
+        return () -> route()
+                .GET("/hello", hostRouterHandler::hello, ops -> ops.operationId("123"))
+                .build();
     }
 }

--- a/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
@@ -1,6 +1,6 @@
 package com.instream.tenant.domain.host.config;
 
-import com.instream.tenant.domain.host.router.HostRouterHandler;
+import com.instream.tenant.domain.host.handler.HostHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RequestPredicates;
@@ -15,24 +15,24 @@ import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
 @Configuration
 public class HostRouterConfig {
     @Bean
-    public RouterFunction<ServerResponse> v1Routes(HostRouterHandler hostRouterHandler) {
+    public RouterFunction<ServerResponse> v1Routes(HostHandler hostHandler) {
         return route().nest(RequestPredicates.path("/v1"),
-                helloFunctionSupplier(hostRouterHandler),
+                helloFunctionSupplier(hostHandler),
                 ops -> ops.operationId("123")
         ).build();
     }
 
     @Bean
-    public RouterFunction<ServerResponse> v2Routes(HostRouterHandler hostRouterHandler) {
+    public RouterFunction<ServerResponse> v2Routes(HostHandler hostHandler) {
         return route().nest(RequestPredicates.path("/v2"),
-                helloFunctionSupplier(hostRouterHandler),
+                helloFunctionSupplier(hostHandler),
                 ops -> ops.operationId("123")
         ).build();
     }
 
-    private Supplier<RouterFunction<ServerResponse>> helloFunctionSupplier(HostRouterHandler hostRouterHandler) {
+    private Supplier<RouterFunction<ServerResponse>> helloFunctionSupplier(HostHandler hostHandler) {
         return () -> route()
-                .GET("/hello", hostRouterHandler::hello, ops -> ops.operationId("123"))
+                .GET("/hello", hostHandler::hello, ops -> ops.operationId("123"))
                 .build();
     }
 }

--- a/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
@@ -1,6 +1,8 @@
 package com.instream.tenant.domain.host.config;
 
+import com.instream.tenant.domain.host.domain.request.TenantCreateRequest;
 import com.instream.tenant.domain.host.handler.HostHandler;
+import org.springdoc.core.fn.builders.parameter.Builder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RequestPredicates;
@@ -9,6 +11,8 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 
 import java.util.function.Supplier;
 
+import static org.springdoc.core.fn.builders.parameter.Builder.parameterBuilder;
+import static org.springdoc.core.fn.builders.requestbody.Builder.requestBodyBuilder;
 import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
 
 
@@ -27,7 +31,12 @@ public class HostRouterConfig {
 
     private RouterFunction<ServerResponse> signUpFunctionSupplier(HostHandler hostHandler) {
         return route()
-                .POST("/sign-up", hostHandler::createTenant, ops -> ops.operationId("123"))
+                .POST(
+                        "/sign-up",
+                        hostHandler::createTenant,
+                        ops -> ops.operationId("123")
+                                .requestBody(requestBodyBuilder().implementation(TenantCreateRequest.class))
+                )
                 .build();
     }
 

--- a/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
@@ -16,23 +16,24 @@ import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
 public class HostRouterConfig {
     @Bean
     public RouterFunction<ServerResponse> v1Routes(HostHandler hostHandler) {
-        return route().nest(RequestPredicates.path("/v1"),
-                helloFunctionSupplier(hostHandler),
+        return route().nest(RequestPredicates.path("/v1/hosts"),
+                builder -> {
+                    builder.add(signUpFunctionSupplier(hostHandler));
+                    builder.add(getUserInfoFunctionSupplier(hostHandler));
+                },
                 ops -> ops.operationId("123")
         ).build();
     }
 
-    @Bean
-    public RouterFunction<ServerResponse> v2Routes(HostHandler hostHandler) {
-        return route().nest(RequestPredicates.path("/v2"),
-                helloFunctionSupplier(hostHandler),
-                ops -> ops.operationId("123")
-        ).build();
+    private RouterFunction<ServerResponse> signUpFunctionSupplier(HostHandler hostHandler) {
+        return route()
+                .POST("/sign-up", hostHandler::createTenant, ops -> ops.operationId("123"))
+                .build();
     }
 
-    private Supplier<RouterFunction<ServerResponse>> helloFunctionSupplier(HostHandler hostHandler) {
-        return () -> route()
-                .GET("/hello", hostHandler::hello, ops -> ops.operationId("123"))
+    private RouterFunction<ServerResponse> getUserInfoFunctionSupplier(HostHandler hostHandler) {
+        return route()
+                .GET("/{hostId}/info", hostHandler::getTenantByAccount, ops -> ops.operationId("123"))
                 .build();
     }
 }

--- a/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
@@ -1,0 +1,18 @@
+package com.instream.tenant.domain.host.config;
+
+import com.instream.tenant.domain.host.router.HostRouterHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
+
+@Configuration
+public class HostRouterConfig {
+    @Bean
+    public RouterFunction<ServerResponse> routes(HostRouterHandler hostRouterHandler) {
+        return route().GET("/hello", hostRouterHandler::hello, ops -> ops
+                .operationId("hello")
+        ).build();
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
@@ -2,14 +2,12 @@ package com.instream.tenant.domain.host.config;
 
 import com.instream.tenant.domain.host.domain.request.TenantCreateRequest;
 import com.instream.tenant.domain.host.handler.HostHandler;
-import org.springdoc.core.fn.builders.parameter.Builder;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
-
-import java.util.function.Supplier;
 
 import static org.springdoc.core.fn.builders.parameter.Builder.parameterBuilder;
 import static org.springdoc.core.fn.builders.requestbody.Builder.requestBodyBuilder;
@@ -42,7 +40,17 @@ public class HostRouterConfig {
 
     private RouterFunction<ServerResponse> getUserInfoFunctionSupplier(HostHandler hostHandler) {
         return route()
-                .GET("/{hostId}/info", hostHandler::getTenantByAccount, ops -> ops.operationId("123"))
+                .GET(
+                        "/{hostId}/info",
+                        hostHandler::getTenantById,
+                        ops -> ops.operationId("123")
+                                .parameter(parameterBuilder()
+                                        .name("hostId")
+                                        .in(ParameterIn.PATH)
+                                        .required(true)
+                                        .example("80bd6328-76a7-11ee-b720-0242ac130003")
+                                )
+                )
                 .build();
     }
 }

--- a/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.RouterFunction;
-import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
 import java.util.function.Supplier;
@@ -16,14 +15,22 @@ import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
 @Configuration
 public class HostRouterConfig {
     @Bean
-    public RouterFunction<ServerResponse> routes(HostRouterHandler hostRouterHandler) {
+    public RouterFunction<ServerResponse> v1Routes(HostRouterHandler hostRouterHandler) {
         return route().nest(RequestPredicates.path("/v1"),
-                routerFunctionSupplier(hostRouterHandler),
+                helloFunctionSupplier(hostRouterHandler),
                 ops -> ops.operationId("123")
         ).build();
     }
 
-    private Supplier<RouterFunction<ServerResponse>> routerFunctionSupplier(HostRouterHandler hostRouterHandler) {
+    @Bean
+    public RouterFunction<ServerResponse> v2Routes(HostRouterHandler hostRouterHandler) {
+        return route().nest(RequestPredicates.path("/v2"),
+                helloFunctionSupplier(hostRouterHandler),
+                ops -> ops.operationId("123")
+        ).build();
+    }
+
+    private Supplier<RouterFunction<ServerResponse>> helloFunctionSupplier(HostRouterHandler hostRouterHandler) {
         return () -> route()
                 .GET("/hello", hostRouterHandler::hello, ops -> ops.operationId("123"))
                 .build();

--- a/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/host/config/HostRouterConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
+
 import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
 
 @Configuration
@@ -12,7 +13,7 @@ public class HostRouterConfig {
     @Bean
     public RouterFunction<ServerResponse> routes(HostRouterHandler hostRouterHandler) {
         return route().GET("/hello", hostRouterHandler::hello, ops -> ops
-                .operationId("hello")
+                .operationId("123")
         ).build();
     }
 }

--- a/src/main/java/com/instream/tenant/domain/host/domain/dto/TenantDto.java
+++ b/src/main/java/com/instream/tenant/domain/host/domain/dto/TenantDto.java
@@ -1,0 +1,23 @@
+package com.instream.tenant.domain.host.domain.dto;
+
+import com.instream.tenant.domain.common.infra.enums.Status;
+import lombok.Builder;
+
+import java.util.UUID;
+
+public record TenantDto(
+        UUID id,
+
+        String account,
+
+        String name,
+
+        Status status,
+
+        String session
+) {
+    @Builder
+    public TenantDto {
+
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/host/domain/entity/TenantEntity.java
+++ b/src/main/java/com/instream/tenant/domain/host/domain/entity/TenantEntity.java
@@ -1,0 +1,32 @@
+package com.instream.tenant.domain.host.domain.entity;
+
+import com.instream.tenant.domain.common.infra.enums.Status;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+@Table(name = "TENANTS")
+public class TenantEntity {
+    @Id
+    private UUID id;
+
+    private String account;
+
+    private String password;
+
+    private Status status;
+
+    private String name;
+
+    private String phoneNum;
+
+    private String secretKey;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/instream/tenant/domain/host/domain/entity/TenantEntity.java
+++ b/src/main/java/com/instream/tenant/domain/host/domain/entity/TenantEntity.java
@@ -4,6 +4,7 @@ import com.instream.tenant.domain.common.infra.enums.Status;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 import java.time.LocalDateTime;
@@ -18,6 +19,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class TenantEntity {
     @Id
+    @Column(value = "tenant_id")
     private UUID id;
 
     private String account;

--- a/src/main/java/com/instream/tenant/domain/host/domain/entity/TenantEntity.java
+++ b/src/main/java/com/instream/tenant/domain/host/domain/entity/TenantEntity.java
@@ -1,6 +1,7 @@
 package com.instream.tenant.domain.host.domain.entity;
 
 import com.instream.tenant.domain.common.infra.enums.Status;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
@@ -10,6 +11,11 @@ import java.util.UUID;
 
 
 @Table(name = "TENANTS")
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TenantEntity {
     @Id
     private UUID id;

--- a/src/main/java/com/instream/tenant/domain/host/domain/request/TenantCreateRequest.java
+++ b/src/main/java/com/instream/tenant/domain/host/domain/request/TenantCreateRequest.java
@@ -1,0 +1,12 @@
+package com.instream.tenant.domain.host.domain.request;
+
+public record TenantCreateRequest(
+        String account,
+
+        String password,
+
+        String name,
+
+        String phoneNumber
+) {
+}

--- a/src/main/java/com/instream/tenant/domain/host/handler/HostHandler.java
+++ b/src/main/java/com/instream/tenant/domain/host/handler/HostHandler.java
@@ -1,6 +1,5 @@
-package com.instream.tenant.domain.host.router;
+package com.instream.tenant.domain.host.handler;
 
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
@@ -8,7 +7,7 @@ import reactor.core.publisher.Mono;
 import static org.springframework.web.reactive.function.server.ServerResponse.ok;
 
 @Component
-public class HostRouterHandler {
+public class HostHandler {
     public Mono<ServerResponse> hello(ServerRequest request) {
         return ok().body(Mono.just("Hello World!"), String.class);
     }

--- a/src/main/java/com/instream/tenant/domain/host/handler/HostHandler.java
+++ b/src/main/java/com/instream/tenant/domain/host/handler/HostHandler.java
@@ -1,14 +1,39 @@
 package com.instream.tenant.domain.host.handler;
 
+import com.instream.tenant.domain.host.domain.request.TenantCreateRequest;
+import com.instream.tenant.domain.host.service.TenantService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
+
 import static org.springframework.web.reactive.function.server.ServerResponse.ok;
 
 @Component
 public class HostHandler {
+    private final TenantService tenantService;
+
+    @Autowired
+    public HostHandler(TenantService tenantService) {
+        this.tenantService = tenantService;
+    }
+
     public Mono<ServerResponse> hello(ServerRequest request) {
         return ok().body(Mono.just("Hello World!"), String.class);
+    }
+
+    public Mono<ServerResponse> getTenantByAccount(ServerRequest request) {
+        String account = request.pathVariable("account");
+        return tenantService.getTenantByAccount(account)
+                .flatMap(tenantDto -> ServerResponse.ok().bodyValue(tenantDto))
+                .switchIfEmpty(ServerResponse.notFound().build());
+    }
+
+    public Mono<ServerResponse> createTenant(ServerRequest request) {
+        return request.bodyToMono(TenantCreateRequest.class)
+                .flatMap(tenantService::createTenant)
+                .flatMap(tenantDto -> ServerResponse.ok().bodyValue(tenantDto))
+                .switchIfEmpty(ServerResponse.badRequest().build());
     }
 }

--- a/src/main/java/com/instream/tenant/domain/host/handler/HostHandler.java
+++ b/src/main/java/com/instream/tenant/domain/host/handler/HostHandler.java
@@ -8,6 +8,8 @@ import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
 
+import java.util.UUID;
+
 import static org.springframework.web.reactive.function.server.ServerResponse.ok;
 
 @Component
@@ -23,9 +25,9 @@ public class HostHandler {
         return ok().body(Mono.just("Hello World!"), String.class);
     }
 
-    public Mono<ServerResponse> getTenantByAccount(ServerRequest request) {
-        String account = request.pathVariable("account");
-        return tenantService.getTenantByAccount(account)
+    public Mono<ServerResponse> getTenantById(ServerRequest request) {
+        String hostId = request.pathVariable("hostId");
+        return tenantService.getTenantById(UUID.fromString(hostId))
                 .flatMap(tenantDto -> ServerResponse.ok().bodyValue(tenantDto))
                 .switchIfEmpty(ServerResponse.notFound().build());
     }

--- a/src/main/java/com/instream/tenant/domain/host/infra/converter/StatusReadConverter.java
+++ b/src/main/java/com/instream/tenant/domain/host/infra/converter/StatusReadConverter.java
@@ -1,0 +1,13 @@
+package com.instream.tenant.domain.host.infra.converter;
+
+import com.instream.tenant.domain.common.infra.enums.Status;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+
+@ReadingConverter
+public class StatusReadConverter implements Converter<String, Status> {
+    @Override
+    public Status convert(String source) {
+        return Status.fromCode(source);
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/host/infra/converter/StatusWriteConverter.java
+++ b/src/main/java/com/instream/tenant/domain/host/infra/converter/StatusWriteConverter.java
@@ -1,0 +1,14 @@
+package com.instream.tenant.domain.host.infra.converter;
+
+import com.instream.tenant.domain.common.infra.enums.Status;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+
+@WritingConverter
+public class StatusWriteConverter implements Converter<Status, String> {
+    @Override
+    public String convert(Status source) {
+        return source.getCode();
+    }
+}
+

--- a/src/main/java/com/instream/tenant/domain/host/infra/enums/TenantErrorCode.java
+++ b/src/main/java/com/instream/tenant/domain/host/infra/enums/TenantErrorCode.java
@@ -1,0 +1,30 @@
+package com.instream.tenant.domain.host.infra.enums;
+
+import com.instream.tenant.domain.error.infra.enums.HttpErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+public enum TenantErrorCode implements HttpErrorCode {
+    TENANT_NOT_FOUND("Tenant not found", HttpStatus.NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    TenantErrorCode(String message, HttpStatus httpStatus) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/host/repository/TenantRepository.java
+++ b/src/main/java/com/instream/tenant/domain/host/repository/TenantRepository.java
@@ -2,8 +2,10 @@ package com.instream.tenant.domain.host.repository;
 
 import com.instream.tenant.domain.host.domain.entity.TenantEntity;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 public interface TenantRepository extends ReactiveCrudRepository<TenantEntity, UUID> {
+    Mono<TenantEntity> findByAccount(String account);
 }

--- a/src/main/java/com/instream/tenant/domain/host/repository/TenantRepository.java
+++ b/src/main/java/com/instream/tenant/domain/host/repository/TenantRepository.java
@@ -1,0 +1,9 @@
+package com.instream.tenant.domain.host.repository;
+
+import com.instream.tenant.domain.host.domain.entity.TenantEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+import java.util.UUID;
+
+public interface TenantRepository extends ReactiveCrudRepository<TenantEntity, UUID> {
+}

--- a/src/main/java/com/instream/tenant/domain/host/router/HostRouterHandler.java
+++ b/src/main/java/com/instream/tenant/domain/host/router/HostRouterHandler.java
@@ -1,0 +1,14 @@
+package com.instream.tenant.domain.host.router;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+import static org.springframework.web.reactive.function.server.ServerResponse.ok;
+
+@Component
+public class HostRouterHandler {
+    public Mono<ServerResponse> hello(ServerRequest request) {
+        return ok().body(Mono.just("Hello World!"), String.class);
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/host/router/HostRouterHandler.java
+++ b/src/main/java/com/instream/tenant/domain/host/router/HostRouterHandler.java
@@ -1,5 +1,6 @@
 package com.instream.tenant.domain.host.router;
 
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;

--- a/src/main/java/com/instream/tenant/domain/host/service/TenantService.java
+++ b/src/main/java/com/instream/tenant/domain/host/service/TenantService.java
@@ -5,6 +5,7 @@ import com.instream.tenant.domain.host.domain.dto.TenantDto;
 import com.instream.tenant.domain.host.domain.entity.TenantEntity;
 import com.instream.tenant.domain.host.domain.request.TenantCreateRequest;
 import com.instream.tenant.domain.host.repository.TenantRepository;
+import com.instream.tenant.domain.redis.factory.ReactiveRedisTemplateFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -18,8 +19,8 @@ public class TenantService {
     private TenantRepository tenantRepository;
 
     @Autowired
-    public TenantService(ReactiveRedisTemplate<String, TenantEntity> redisTemplate, TenantRepository tenantRepository) {
-        this.redisTemplate = redisTemplate;
+    public TenantService(ReactiveRedisTemplateFactory redisTemplateFactory, TenantRepository tenantRepository) {
+        this.redisTemplate = redisTemplateFactory.getTemplate(TenantEntity.class);
         this.tenantRepository = tenantRepository;
     }
 

--- a/src/main/java/com/instream/tenant/domain/host/service/TenantService.java
+++ b/src/main/java/com/instream/tenant/domain/host/service/TenantService.java
@@ -28,18 +28,14 @@ public class TenantService {
     public Mono<TenantDto> getTenantById(UUID tenantId) {
         return redisTemplate.opsForValue()
                 .get(tenantId.toString())
-                .switchIfEmpty(Mono.defer(() -> {
-                            System.out.println("hello123123");
-                            return tenantRepository.findById(tenantId).flatMap(tenant -> {
-                                System.out.println("hello123");
-                                return redisTemplate.opsForValue()
-                                        .set(String.valueOf(tenantId), tenant)
-                                        .thenReturn(tenant);
-                            });
-                        }
-                ))
+                .switchIfEmpty(Mono.defer(() -> tenantRepository.findById(tenantId)
+                        .flatMap(tenant -> redisTemplate.opsForValue()
+                                .set(String.valueOf(tenantId), tenant)
+                                .thenReturn(tenant))))
                 // TODO: Tenant mapper
                 .map(tenant -> TenantDto.builder()
+                        .id(tenant.getId())
+                        .account(tenant.getAccount())
                         .name(tenant.getName())
                         .status(tenant.getStatus())
                         // TODO: 세션

--- a/src/main/java/com/instream/tenant/domain/host/service/TenantService.java
+++ b/src/main/java/com/instream/tenant/domain/host/service/TenantService.java
@@ -1,0 +1,72 @@
+package com.instream.tenant.domain.host.service;
+
+import com.instream.tenant.domain.common.infra.enums.Status;
+import com.instream.tenant.domain.host.domain.dto.TenantDto;
+import com.instream.tenant.domain.host.domain.entity.TenantEntity;
+import com.instream.tenant.domain.host.domain.request.TenantCreateRequest;
+import com.instream.tenant.domain.host.repository.TenantRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Service
+public class TenantService {
+    private ReactiveRedisTemplate<String, TenantEntity> redisTemplate;
+
+    private TenantRepository tenantRepository;
+
+    @Autowired
+    public TenantService(ReactiveRedisTemplate<String, TenantEntity> redisTemplate, TenantRepository tenantRepository) {
+        this.redisTemplate = redisTemplate;
+        this.tenantRepository = tenantRepository;
+    }
+
+    public Mono<TenantDto> getTenantByAccount(String account) {
+        return redisTemplate.opsForValue()
+                .get(account)
+                .switchIfEmpty(Mono.defer(() -> tenantRepository.findByAccount(account)
+                        .flatMap(tenant -> redisTemplate.opsForValue()
+                                .set(account, tenant)
+                                .thenReturn(tenant))))
+                // TODO: Tenant mapper
+                .map(tenant -> TenantDto.builder()
+                        .name(tenant.getName())
+                        .status(tenant.getStatus())
+                        // TODO: 세션
+                        .session("")
+                        .build());
+    }
+
+
+    public Mono<TenantDto> createTenant(TenantCreateRequest tenantCreateRequest) {
+        return tenantRepository.findByAccount(tenantCreateRequest.account())
+                // TODO: 글로벌 에러 핸들링
+                .flatMap(existingTenant -> Mono.<TenantDto>error(new RuntimeException("Tenant already exists")))
+                .switchIfEmpty(Mono.defer(() -> {
+                    TenantEntity newTenant = TenantEntity.builder()
+                            .account(tenantCreateRequest.account())
+                            .password(tenantCreateRequest.password())
+                            .name(tenantCreateRequest.name())
+                            .phoneNum(tenantCreateRequest.phoneNumber())
+                            .status(Status.USE)
+                            .secretKey("")
+                            .build();
+
+                    return tenantRepository.save(newTenant)
+                            .flatMap(savedTenant -> Mono.just(TenantDto.builder()
+                                    .id(savedTenant.getId())
+                                    .account(savedTenant.getAccount())
+                                    .name(savedTenant.getName())
+                                    .status(savedTenant.getStatus())
+                                    .session("")
+                                    .build()
+                            ));
+                }));
+        // TODO:
+        //  1. 캐싱 필요한지?
+        //  2. 필요하다면 DTO랑 Entity 중에 어떤 걸 캐싱할 건지?
+        //  3. DTO랑 Entity 캐싱할 때 key 값 분리는 어떻게 할건지?
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/redis/factory/ReactiveRedisTemplateFactory.java
+++ b/src/main/java/com/instream/tenant/domain/redis/factory/ReactiveRedisTemplateFactory.java
@@ -1,5 +1,7 @@
 package com.instream.tenant.domain.redis.factory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
@@ -13,12 +15,16 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 public class ReactiveRedisTemplateFactory {
-
     private final ReactiveRedisConnectionFactory factory;
+
     private final ConcurrentHashMap<Class<?>, ReactiveRedisTemplate<String, ?>> templateCache = new ConcurrentHashMap<>();
 
-    public ReactiveRedisTemplateFactory(ReactiveRedisConnectionFactory factory) {
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public ReactiveRedisTemplateFactory(ReactiveRedisConnectionFactory factory, ObjectMapper objectMapper) {
         this.factory = factory;
+        this.objectMapper = objectMapper;
     }
 
     public <T> ReactiveRedisTemplate<String, T> getTemplate(Class<T> clazz) {
@@ -26,7 +32,7 @@ public class ReactiveRedisTemplateFactory {
     }
 
     private <T> ReactiveRedisTemplate<String, T> createReactiveRedisTemplate(Class<T> clazz) {
-        Jackson2JsonRedisSerializer<T> serializer = new Jackson2JsonRedisSerializer<>(clazz);
+        Jackson2JsonRedisSerializer<T> serializer = new Jackson2JsonRedisSerializer<>(objectMapper, clazz);
         RedisSerializationContext.RedisSerializationContextBuilder<String, T> builder =
                 RedisSerializationContext.newSerializationContext(new StringRedisSerializer());
 

--- a/src/main/java/com/instream/tenant/domain/redis/factory/ReactiveRedisTemplateFactory.java
+++ b/src/main/java/com/instream/tenant/domain/redis/factory/ReactiveRedisTemplateFactory.java
@@ -1,0 +1,37 @@
+package com.instream.tenant.domain.redis.factory;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class ReactiveRedisTemplateFactory {
+
+    private final ReactiveRedisConnectionFactory factory;
+    private final ConcurrentHashMap<Class<?>, ReactiveRedisTemplate<String, ?>> templateCache = new ConcurrentHashMap<>();
+
+    public ReactiveRedisTemplateFactory(ReactiveRedisConnectionFactory factory) {
+        this.factory = factory;
+    }
+
+    public <T> ReactiveRedisTemplate<String, T> getTemplate(Class<T> clazz) {
+        return (ReactiveRedisTemplate<String, T>) templateCache.computeIfAbsent(clazz, this::createReactiveRedisTemplate);
+    }
+
+    private <T> ReactiveRedisTemplate<String, T> createReactiveRedisTemplate(Class<T> clazz) {
+        Jackson2JsonRedisSerializer<T> serializer = new Jackson2JsonRedisSerializer<>(clazz);
+        RedisSerializationContext.RedisSerializationContextBuilder<String, T> builder =
+                RedisSerializationContext.newSerializationContext(new StringRedisSerializer());
+
+        RedisSerializationContext<String, T> context = builder.value(serializer).build();
+
+        return new ReactiveRedisTemplate<>(factory, context);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,20 +16,18 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MariaDBDialect
+  webflux:
+    base-path: /api
 
 springdoc:
   swagger-ui:
-    path: /api/swagger-ui.html
+    path: /swagger-ui.html
     enabled: true
   api-docs:
     path: /v3/api-docs
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
   model-and-view-allowed: true
-
-server:
-  servlet:
-    context-path: /api
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,19 +16,22 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MariaDBDialect
-  level:
-    org:
-      springframework=trace:
-        info
 
 springdoc:
   swagger-ui:
-    enabled: true # swagger ui ???? (?? ???? ??? default? true)
-  version: 'v1' # API ?? ??
-  default-consumes-media-type: application/json # ?? consume media type
-  default-produces-media-type: application/json # ?? produce media type
-  model-and-view-allowed: true # ModelAndView ??
+    path: /api/swagger-ui.html
+    enabled: true
+  api-docs:
+    path: /v3/api-docs
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  model-and-view-allowed: true
 
 server:
   servlet:
     context-path: /api
+
+logging:
+  level:
+    org.springframework.web: DEBUG
+    org.springdoc: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 spring:
-  datasource:
-    url: jdbc:mariadb://${MARIA_IP}:${MARIA_PORT}/${MARIA_DATABASE}?useSSL=false&serverTimezone=UTC
-    driver-class-name: org.mariadb.jdbc.Driver
+  r2dbc:
+    url: r2dbc:mariadb://${MARIA_IP}:${MARIA_PORT}/${MARIA_DATABASE}?useSSL=false&serverTimezone=UTC
     username: ${MARIA_USERNAME}
     password: ${MARIA_PASSWORD}
   data:


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- GlobalErrorWebExceptionHandler를 통해 ErrorWebExceptionHandler 구현
- HttpErrorCode interface, RestApiException, ErrorResponse 도입
- HostHandler, TenantService에 테스트용 에러 핸들링 추가

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 리펙토링

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- webflux 기본 ErrorWebExceptionHandler class 순서가 @Order(-1) 여서, GlobalErrorWebExceptionHandler는 @Order(-2)로 우선순위를 높였습니다.
- 
<br/><br/>
