### PR TITLE
<FEAT> 기업서비스 이용자 접속하기 & 접속끊기 API 구현

### DIFF
--- a/src/main/java/com/instream/tenant/core/config/R2dbcConfig.java
+++ b/src/main/java/com/instream/tenant/core/config/R2dbcConfig.java
@@ -4,8 +4,8 @@ import com.instream.tenant.domain.application.infra.converter.applicationType.Ap
 import com.instream.tenant.domain.application.infra.converter.applicationType.ApplicationTypeWriteConverter;
 import com.instream.tenant.domain.common.infra.converter.uuid.UUIDReadConverter;
 import com.instream.tenant.domain.common.infra.converter.uuid.UUIDWriteConverter;
-import com.instream.tenant.domain.host.infra.converter.StatusReadConverter;
-import com.instream.tenant.domain.host.infra.converter.StatusWriteConverter;
+import com.instream.tenant.domain.tenant.infra.converter.StatusReadConverter;
+import com.instream.tenant.domain.tenant.infra.converter.StatusWriteConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;

--- a/src/main/java/com/instream/tenant/domain/application/domain/entity/ApplicationEntity.java
+++ b/src/main/java/com/instream/tenant/domain/application/domain/entity/ApplicationEntity.java
@@ -2,7 +2,6 @@ package com.instream.tenant.domain.application.domain.entity;
 
 import com.instream.tenant.domain.application.infra.enums.ApplicationType;
 import com.instream.tenant.domain.common.infra.enums.Status;
-import com.instream.tenant.domain.host.domain.entity.TenantEntity;
 import com.instream.tenant.domain.redis.domain.entity.RedisEntity;
 import lombok.*;
 import org.springframework.data.annotation.Id;

--- a/src/main/java/com/instream/tenant/domain/application/handler/ApplicationHandler.java
+++ b/src/main/java/com/instream/tenant/domain/application/handler/ApplicationHandler.java
@@ -6,6 +6,7 @@ import com.instream.tenant.domain.application.service.ApplicationService;
 import com.instream.tenant.domain.error.infra.enums.CommonHttpErrorCode;
 import com.instream.tenant.domain.error.model.exception.RestApiException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
@@ -57,6 +58,12 @@ public class ApplicationHandler {
     }
 
     public Mono startApplication(ServerRequest request) {
+        String apiKey = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
+
+        if (apiKey == null || apiKey.isEmpty()) {
+            return Mono.error(new RestApiException(CommonHttpErrorCode.UNAUTHORIZED));
+        }
+
         UUID hostId;
         UUID applicationId;
 
@@ -67,10 +74,16 @@ public class ApplicationHandler {
             return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
         }
 
-        return applicationService.startApplication(applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
+        return applicationService.startApplication(apiKey, applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
     }
 
     public Mono endApplication(ServerRequest request) {
+        String apiKey = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
+
+        if (apiKey == null || apiKey.isEmpty()) {
+            return Mono.error(new RestApiException(CommonHttpErrorCode.UNAUTHORIZED));
+        }
+
         UUID hostId;
         UUID applicationId;
 
@@ -81,11 +94,17 @@ public class ApplicationHandler {
             return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
         }
 
-        return applicationService.endApplication(applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
+        return applicationService.endApplication(apiKey, applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
     }
 
 
     public Mono deleteApplication(ServerRequest request) {
+        String apiKey = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
+
+        if (apiKey == null || apiKey.isEmpty()) {
+            return Mono.error(new RestApiException(CommonHttpErrorCode.UNAUTHORIZED));
+        }
+
         UUID hostId;
         UUID applicationId;
 
@@ -96,6 +115,6 @@ public class ApplicationHandler {
             return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
         }
 
-        return applicationService.deleteApplication(applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
+        return applicationService.deleteApplication(apiKey, applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
     }
 }

--- a/src/main/java/com/instream/tenant/domain/application/handler/ApplicationHandler.java
+++ b/src/main/java/com/instream/tenant/domain/application/handler/ApplicationHandler.java
@@ -30,7 +30,7 @@ public class ApplicationHandler {
         try {
             hostId = UUID.fromString(request.pathVariable("hostId"));
         } catch (IllegalArgumentException illegalArgumentException) {
-            throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
+            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
         }
 
         return ApplicationSearchPaginationOptionRequest.fromQueryParams(request.queryParams())
@@ -46,7 +46,7 @@ public class ApplicationHandler {
         try {
             hostId = UUID.fromString(request.pathVariable("hostId"));
         } catch (IllegalArgumentException illegalArgumentException) {
-            throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
+            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
         }
 
         return request.bodyToMono(ApplicationCreateRequest.class)
@@ -64,7 +64,7 @@ public class ApplicationHandler {
             hostId = UUID.fromString(request.pathVariable("hostId"));
             applicationId = UUID.fromString(request.pathVariable("applicationId"));
         } catch (IllegalArgumentException illegalArgumentException) {
-            throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
+            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
         }
 
         return applicationService.startApplication(applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
@@ -78,7 +78,7 @@ public class ApplicationHandler {
             hostId = UUID.fromString(request.pathVariable("hostId"));
             applicationId = UUID.fromString(request.pathVariable("applicationId"));
         } catch (IllegalArgumentException illegalArgumentException) {
-            throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
+            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
         }
 
         return applicationService.endApplication(applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
@@ -93,7 +93,7 @@ public class ApplicationHandler {
             hostId = UUID.fromString(request.pathVariable("hostId"));
             applicationId = UUID.fromString(request.pathVariable("applicationId"));
         } catch (IllegalArgumentException illegalArgumentException) {
-            throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
+            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
         }
 
         return applicationService.deleteApplication(applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));

--- a/src/main/java/com/instream/tenant/domain/application/infra/enums/ApplicationErrorCode.java
+++ b/src/main/java/com/instream/tenant/domain/application/infra/enums/ApplicationErrorCode.java
@@ -4,7 +4,8 @@ import com.instream.tenant.domain.error.infra.enums.HttpErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum ApplicationErrorCode implements HttpErrorCode {
-    APPLICATION_NOT_FOUND("어플리케이션을 찾지 못 했습니다.", HttpStatus.NOT_FOUND);
+    APPLICATION_NOT_FOUND("어플리케이션을 찾지 못 했습니다.", HttpStatus.NOT_FOUND),
+    APPLICATION_NOT_SUPPORTED("해당 어플리케이션 종류는 지원하지 않습니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/instream/tenant/domain/application/infra/enums/ApplicationSessionErrorCode.java
+++ b/src/main/java/com/instream/tenant/domain/application/infra/enums/ApplicationSessionErrorCode.java
@@ -4,7 +4,8 @@ import com.instream.tenant.domain.error.infra.enums.HttpErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum ApplicationSessionErrorCode implements HttpErrorCode {
-    APPLICATION_SESSION_NOT_FOUND("어플리케이션 세션을 찾지 못 했습니다.", HttpStatus.NOT_FOUND);
+    APPLICATION_SESSION_NOT_FOUND("어플리케이션 세션을 찾지 못 했습니다.", HttpStatus.NOT_FOUND),
+   APPLICATION_SESSION_ALREADY_ENDED("이미 종료된 어플리케이션 세션입니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/instream/tenant/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/instream/tenant/domain/application/repository/ApplicationRepository.java
@@ -18,6 +18,8 @@ public interface ApplicationRepository extends QuerydslR2dbcRepository<Applicati
 
     Mono<ApplicationEntity> findByIdAndTenantId(UUID id, UUID tenantId);
 
+    Mono<ApplicationEntity> findByApiKey(String apiKey);
+
     Mono<Void> deleteByIdAndTenantId(UUID id, UUID tenantId);
 
     Mono<Long> count(Predicate predicate);

--- a/src/main/java/com/instream/tenant/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/instream/tenant/domain/application/service/ApplicationService.java
@@ -5,6 +5,7 @@ import com.instream.tenant.domain.application.domain.entity.ApplicationSessionEn
 import com.instream.tenant.domain.application.domain.request.ApplicationSearchPaginationOptionRequest;
 import com.instream.tenant.domain.application.infra.enums.ApplicationErrorCode;
 import com.instream.tenant.domain.application.infra.enums.ApplicationSessionErrorCode;
+import com.instream.tenant.domain.application.infra.enums.ApplicationType;
 import com.instream.tenant.domain.application.model.specification.ApplicationSpecification;
 import com.instream.tenant.domain.application.repository.ApplicationRepository;
 import com.instream.tenant.domain.application.domain.dto.ApplicationDto;
@@ -143,6 +144,9 @@ public class ApplicationService {
                 .flatMap(application -> {
                     boolean isOff = application.getStatus() == Status.PENDING;
 
+                    if (application.getType() == ApplicationType.STREAMING) {
+                        return Mono.error(new RestApiException(ApplicationErrorCode.APPLICATION_NOT_SUPPORTED));
+                    }
                     if (isOff) {
                         return createApplicationSession(applicationId, application);
                     }
@@ -157,6 +161,9 @@ public class ApplicationService {
                 .flatMap(application -> {
                     boolean isOn = application.getStatus() == Status.USE;
 
+                    if (application.getType() == ApplicationType.STREAMING) {
+                        return Mono.error(new RestApiException(ApplicationErrorCode.APPLICATION_NOT_SUPPORTED));
+                    }
                     if (isOn) {
                         return deleteApplicationSession(applicationId, application);
                     }

--- a/src/main/java/com/instream/tenant/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/instream/tenant/domain/application/service/ApplicationService.java
@@ -148,7 +148,7 @@ public class ApplicationService {
                         return Mono.error(new RestApiException(ApplicationErrorCode.APPLICATION_NOT_SUPPORTED));
                     }
                     if (isOff) {
-                        return createApplicationSession(applicationId, application);
+                        return createApplicationSession(application);
                     }
 
                     return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
@@ -165,7 +165,7 @@ public class ApplicationService {
                         return Mono.error(new RestApiException(ApplicationErrorCode.APPLICATION_NOT_SUPPORTED));
                     }
                     if (isOn) {
-                        return deleteApplicationSession(applicationId, application);
+                        return deleteApplicationSession(application);
                     }
 
                     return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
@@ -177,9 +177,9 @@ public class ApplicationService {
                 .then(Mono.defer(() -> applicationRepository.deleteByIdAndTenantId(applicationId, hostId)));
     }
 
-    private Mono<Void> createApplicationSession(UUID applicationId, ApplicationEntity application) {
+    private Mono<Void> createApplicationSession(ApplicationEntity application) {
         ApplicationSessionEntity applicationSessionEntity = ApplicationSessionEntity.builder()
-                .applicationId(applicationId)
+                .applicationId(application.getId())
                 .build();
 
         return applicationSessionRepository.save(applicationSessionEntity)
@@ -189,8 +189,8 @@ public class ApplicationService {
                 }));
     }
 
-    private Mono<Void> deleteApplicationSession(UUID applicationId, ApplicationEntity application) {
-        return applicationSessionRepository.findTopByApplicationIdOrderByCreatedAtDesc(applicationId)
+    private Mono<Void> deleteApplicationSession(ApplicationEntity application) {
+        return applicationSessionRepository.findTopByApplicationIdOrderByCreatedAtDesc(application.getId())
                 .switchIfEmpty(Mono.error(new RestApiException(ApplicationSessionErrorCode.APPLICATION_SESSION_NOT_FOUND)))
                 .flatMap(applicationSession -> {
                     applicationSession.setDeletedAt(LocalDateTime.now());

--- a/src/main/java/com/instream/tenant/domain/error/handler/GlobalErrorWebExceptionHandler.java
+++ b/src/main/java/com/instream/tenant/domain/error/handler/GlobalErrorWebExceptionHandler.java
@@ -34,6 +34,7 @@ public class GlobalErrorWebExceptionHandler implements ErrorWebExceptionHandler 
 
     @Override
     public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+        System.out.println(String.format("error123 %s", ex));
         if (ex instanceof RestApiException restApiException) {
             log.error("handleRestApiException", ex);
             return writeResponse(restApiException.getHttpErrorCode(), exchange);

--- a/src/main/java/com/instream/tenant/domain/error/infra/enums/CommonHttpErrorCode.java
+++ b/src/main/java/com/instream/tenant/domain/error/infra/enums/CommonHttpErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommonHttpErrorCode implements HttpErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 에러가 발생했습니다."),
     SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "해당 서비스가 이용 불가능합니다.");

--- a/src/main/java/com/instream/tenant/domain/media/config/MediaRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/media/config/MediaRouterConfig.java
@@ -1,0 +1,71 @@
+package com.instream.tenant.domain.media.config;
+
+import com.instream.tenant.domain.application.domain.dto.ApplicationSessionDto;
+import com.instream.tenant.domain.application.handler.ApplicationHandler;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import org.springdoc.core.fn.builders.apiresponse.Builder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.springdoc.core.fn.builders.parameter.Builder.parameterBuilder;
+import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
+
+
+@Configuration
+public class MediaRouterConfig {
+    @Bean
+    public RouterFunction<ServerResponse> v1MediaRoutes(ApplicationHandler applicationHandler) {
+        return route().nest(RequestPredicates.path("/v1/medias"),
+                builder -> {
+                    builder.add(startLive(applicationHandler));
+                    builder.add(endLive(applicationHandler));
+                },
+                ops -> ops.operationId("123")
+        ).build();
+    }
+    
+    private RouterFunction<ServerResponse> startLive(ApplicationHandler applicationHandler) {
+        return route()
+                .PATCH(
+                        "/lives/start",
+                        applicationHandler::startApplication,
+                        ops -> ops.operationId("123")
+                                .parameter(parameterBuilder()
+                                        .name("hostId")
+                                        .in(ParameterIn.PATH)
+                                        .required(true)
+                                        .example("80bd6328-76a7-11ee-b720-0242ac130003"))
+                                .parameter(parameterBuilder()
+                                        .name("applicationId")
+                                        .in(ParameterIn.PATH)
+                                        .required(true)
+                                        .example("80bd6328-76a7-11ee-b720-0242ac130003"))
+                                .response(Builder.responseBuilder().implementation(ApplicationSessionDto.class))
+                )
+                .build();
+    }
+
+    private RouterFunction<ServerResponse> endLive(ApplicationHandler applicationHandler) {
+        return route()
+                .PATCH(
+                        "/lives/end",
+                        applicationHandler::endApplication,
+                        ops -> ops.operationId("123")
+                                .parameter(parameterBuilder()
+                                        .name("hostId")
+                                        .in(ParameterIn.PATH)
+                                        .required(true)
+                                        .example("80bd6328-76a7-11ee-b720-0242ac130003"))
+                                .parameter(parameterBuilder()
+                                        .name("applicationId")
+                                        .in(ParameterIn.PATH)
+                                        .required(true)
+                                        .example("80bd6328-76a7-11ee-b720-0242ac130003"))
+                                .response(Builder.responseBuilder().implementation(ApplicationSessionDto.class))
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/media/config/MediaRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/media/config/MediaRouterConfig.java
@@ -2,6 +2,7 @@ package com.instream.tenant.domain.media.config;
 
 import com.instream.tenant.domain.application.domain.dto.ApplicationSessionDto;
 import com.instream.tenant.domain.application.handler.ApplicationHandler;
+import com.instream.tenant.domain.media.handler.MediaHandler;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import org.springdoc.core.fn.builders.apiresponse.Builder;
 import org.springframework.context.annotation.Bean;
@@ -17,21 +18,21 @@ import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
 @Configuration
 public class MediaRouterConfig {
     @Bean
-    public RouterFunction<ServerResponse> v1MediaRoutes(ApplicationHandler applicationHandler) {
+    public RouterFunction<ServerResponse> v1MediaRoutes(MediaHandler mediaHandler) {
         return route().nest(RequestPredicates.path("/v1/medias"),
                 builder -> {
-                    builder.add(startLive(applicationHandler));
-                    builder.add(endLive(applicationHandler));
+                    builder.add(startLive(mediaHandler));
+                    builder.add(endLive(mediaHandler));
                 },
                 ops -> ops.operationId("123")
         ).build();
     }
     
-    private RouterFunction<ServerResponse> startLive(ApplicationHandler applicationHandler) {
+    private RouterFunction<ServerResponse> startLive(MediaHandler mediaHandler) {
         return route()
                 .PATCH(
                         "/lives/start",
-                        applicationHandler::startApplication,
+                        mediaHandler::startApplication,
                         ops -> ops.operationId("123")
                                 .parameter(parameterBuilder()
                                         .name("hostId")
@@ -48,11 +49,11 @@ public class MediaRouterConfig {
                 .build();
     }
 
-    private RouterFunction<ServerResponse> endLive(ApplicationHandler applicationHandler) {
+    private RouterFunction<ServerResponse> endLive(MediaHandler mediaHandler) {
         return route()
                 .PATCH(
                         "/lives/end",
-                        applicationHandler::endApplication,
+                        mediaHandler::endApplication,
                         ops -> ops.operationId("123")
                                 .parameter(parameterBuilder()
                                         .name("hostId")

--- a/src/main/java/com/instream/tenant/domain/media/config/MediaRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/media/config/MediaRouterConfig.java
@@ -1,7 +1,6 @@
 package com.instream.tenant.domain.media.config;
 
 import com.instream.tenant.domain.application.domain.dto.ApplicationSessionDto;
-import com.instream.tenant.domain.application.handler.ApplicationHandler;
 import com.instream.tenant.domain.media.handler.MediaHandler;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import org.springdoc.core.fn.builders.apiresponse.Builder;
@@ -27,13 +26,19 @@ public class MediaRouterConfig {
                 ops -> ops.operationId("123")
         ).build();
     }
-    
+
     private RouterFunction<ServerResponse> startLive(MediaHandler mediaHandler) {
         return route()
                 .PATCH(
                         "/lives/start",
-                        mediaHandler::startApplication,
+                        mediaHandler::startLive,
                         ops -> ops.operationId("123")
+                                .parameter(parameterBuilder()
+                                        .name("Authorization")
+                                        .in(ParameterIn.HEADER)
+                                        .required(true)
+                                        .example("80bd6328-76a7-11ee-b720-0242ac130003")
+                                )
                                 .parameter(parameterBuilder()
                                         .name("hostId")
                                         .in(ParameterIn.PATH)
@@ -53,8 +58,14 @@ public class MediaRouterConfig {
         return route()
                 .PATCH(
                         "/lives/end",
-                        mediaHandler::endApplication,
+                        mediaHandler::endLive,
                         ops -> ops.operationId("123")
+                                .parameter(parameterBuilder()
+                                        .name("Authorization")
+                                        .in(ParameterIn.HEADER)
+                                        .required(true)
+                                        .example("80bd6328-76a7-11ee-b720-0242ac130003")
+                                )
                                 .parameter(parameterBuilder()
                                         .name("hostId")
                                         .in(ParameterIn.PATH)

--- a/src/main/java/com/instream/tenant/domain/media/handler/MediaHandler.java
+++ b/src/main/java/com/instream/tenant/domain/media/handler/MediaHandler.java
@@ -1,6 +1,6 @@
 package com.instream.tenant.domain.media.handler;
 
-import com.instream.tenant.domain.application.service.ApplicationService;
+import com.instream.tenant.domain.application.domain.dto.ApplicationSessionDto;
 import com.instream.tenant.domain.error.infra.enums.CommonHttpErrorCode;
 import com.instream.tenant.domain.error.model.exception.RestApiException;
 import com.instream.tenant.domain.media.service.MediaService;
@@ -10,8 +10,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
-
-import java.util.UUID;
 
 @Component
 public class MediaHandler {
@@ -23,23 +21,23 @@ public class MediaHandler {
         this.mediaService = mediaService;
     }
 
-    public Mono startApplication(ServerRequest request) {
+    public Mono<ServerResponse> startLive(ServerRequest request) {
         String apiKey = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
 
         if (apiKey == null || apiKey.isEmpty()) {
             return Mono.error(new RestApiException(CommonHttpErrorCode.UNAUTHORIZED));
         }
 
-        return mediaService.startLive(apiKey).then(Mono.defer(() -> ServerResponse.ok().build()));
+        return mediaService.startLive(apiKey).flatMap(applicationSession -> ServerResponse.ok().bodyValue(applicationSession));
     }
 
-    public Mono endApplication(ServerRequest request) {
+    public Mono<ServerResponse> endLive(ServerRequest request) {
         String apiKey = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
 
         if (apiKey == null || apiKey.isEmpty()) {
             return Mono.error(new RestApiException(CommonHttpErrorCode.UNAUTHORIZED));
         }
 
-        return mediaService.endLive(apiKey).then(Mono.defer(() -> ServerResponse.ok().build()));
+        return mediaService.endLive(apiKey).flatMap(applicationSession -> ServerResponse.ok().bodyValue(applicationSession));
     }
 }

--- a/src/main/java/com/instream/tenant/domain/media/handler/MediaHandler.java
+++ b/src/main/java/com/instream/tenant/domain/media/handler/MediaHandler.java
@@ -1,0 +1,67 @@
+package com.instream.tenant.domain.media.handler;
+
+import com.instream.tenant.domain.application.domain.request.ApplicationCreateRequest;
+import com.instream.tenant.domain.application.domain.request.ApplicationSearchPaginationOptionRequest;
+import com.instream.tenant.domain.application.service.ApplicationService;
+import com.instream.tenant.domain.error.infra.enums.CommonHttpErrorCode;
+import com.instream.tenant.domain.error.model.exception.RestApiException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.UUID;
+
+@Component
+public class MediaHandler {
+
+    private final ApplicationService applicationService;
+
+    @Autowired
+    public MediaHandler(ApplicationService applicationService) {
+        this.applicationService = applicationService;
+    }
+
+    public Mono startApplication(ServerRequest request) {
+        String authorizationHeader = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authorizationHeader == null || authorizationHeader.isEmpty()) {
+            return Mono.error(new RestApiException(CommonHttpErrorCode.UNAUTHORIZED));
+        }
+
+        UUID hostId;
+        UUID applicationId;
+
+        try {
+            hostId = UUID.fromString(request.pathVariable("hostId"));
+            applicationId = UUID.fromString(request.pathVariable("applicationId"));
+        } catch (IllegalArgumentException illegalArgumentException) {
+            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
+        }
+
+        return applicationService.startApplication(applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
+    }
+
+    public Mono endApplication(ServerRequest request) {
+        String authorizationHeader = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authorizationHeader == null || authorizationHeader.isEmpty()) {
+            return Mono.error(new RestApiException(CommonHttpErrorCode.UNAUTHORIZED));
+        }
+
+        UUID hostId;
+        UUID applicationId;
+
+        try {
+            hostId = UUID.fromString(request.pathVariable("hostId"));
+            applicationId = UUID.fromString(request.pathVariable("applicationId"));
+        } catch (IllegalArgumentException illegalArgumentException) {
+            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
+        }
+
+        return applicationService.endApplication(applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/media/handler/MediaHandler.java
+++ b/src/main/java/com/instream/tenant/domain/media/handler/MediaHandler.java
@@ -1,10 +1,9 @@
 package com.instream.tenant.domain.media.handler;
 
-import com.instream.tenant.domain.application.domain.request.ApplicationCreateRequest;
-import com.instream.tenant.domain.application.domain.request.ApplicationSearchPaginationOptionRequest;
 import com.instream.tenant.domain.application.service.ApplicationService;
 import com.instream.tenant.domain.error.infra.enums.CommonHttpErrorCode;
 import com.instream.tenant.domain.error.model.exception.RestApiException;
+import com.instream.tenant.domain.media.service.MediaService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -12,56 +11,35 @@ import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
 
-import java.net.URI;
 import java.util.UUID;
 
 @Component
 public class MediaHandler {
 
-    private final ApplicationService applicationService;
+    private final MediaService mediaService;
 
     @Autowired
-    public MediaHandler(ApplicationService applicationService) {
-        this.applicationService = applicationService;
+    public MediaHandler(MediaService mediaService) {
+        this.mediaService = mediaService;
     }
 
     public Mono startApplication(ServerRequest request) {
-        String authorizationHeader = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
+        String apiKey = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
 
-        if (authorizationHeader == null || authorizationHeader.isEmpty()) {
+        if (apiKey == null || apiKey.isEmpty()) {
             return Mono.error(new RestApiException(CommonHttpErrorCode.UNAUTHORIZED));
         }
 
-        UUID hostId;
-        UUID applicationId;
-
-        try {
-            hostId = UUID.fromString(request.pathVariable("hostId"));
-            applicationId = UUID.fromString(request.pathVariable("applicationId"));
-        } catch (IllegalArgumentException illegalArgumentException) {
-            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
-        }
-
-        return applicationService.startApplication(applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
+        return mediaService.startLive(apiKey).then(Mono.defer(() -> ServerResponse.ok().build()));
     }
 
     public Mono endApplication(ServerRequest request) {
-        String authorizationHeader = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
+        String apiKey = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
 
-        if (authorizationHeader == null || authorizationHeader.isEmpty()) {
+        if (apiKey == null || apiKey.isEmpty()) {
             return Mono.error(new RestApiException(CommonHttpErrorCode.UNAUTHORIZED));
         }
 
-        UUID hostId;
-        UUID applicationId;
-
-        try {
-            hostId = UUID.fromString(request.pathVariable("hostId"));
-            applicationId = UUID.fromString(request.pathVariable("applicationId"));
-        } catch (IllegalArgumentException illegalArgumentException) {
-            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
-        }
-
-        return applicationService.endApplication(applicationId, hostId).then(Mono.defer(() -> ServerResponse.ok().build()));
+        return mediaService.endLive(apiKey).then(Mono.defer(() -> ServerResponse.ok().build()));
     }
 }

--- a/src/main/java/com/instream/tenant/domain/media/service/MediaService.java
+++ b/src/main/java/com/instream/tenant/domain/media/service/MediaService.java
@@ -1,0 +1,102 @@
+package com.instream.tenant.domain.media.service;
+
+import com.instream.tenant.domain.application.domain.entity.ApplicationEntity;
+import com.instream.tenant.domain.application.domain.entity.ApplicationSessionEntity;
+import com.instream.tenant.domain.application.infra.enums.ApplicationErrorCode;
+import com.instream.tenant.domain.application.infra.enums.ApplicationSessionErrorCode;
+import com.instream.tenant.domain.application.infra.enums.ApplicationType;
+import com.instream.tenant.domain.application.repository.ApplicationRepository;
+import com.instream.tenant.domain.application.repository.ApplicationSessionRepository;
+import com.instream.tenant.domain.common.infra.enums.Status;
+import com.instream.tenant.domain.error.infra.enums.CommonHttpErrorCode;
+import com.instream.tenant.domain.error.model.exception.RestApiException;
+import com.instream.tenant.domain.participant.repository.ParticipantJoinRepository;
+import com.instream.tenant.domain.redis.model.factory.ReactiveRedisTemplateFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class MediaService {
+    private final ReactiveRedisTemplate<String, ApplicationEntity> redisTemplate;
+
+    private final ApplicationRepository applicationRepository;
+
+    private final ApplicationSessionRepository applicationSessionRepository;
+
+    private final ParticipantJoinRepository participantJoinRepository;
+
+    @Autowired
+    public MediaService(ReactiveRedisTemplateFactory redisTemplateFactory, ApplicationRepository applicationRepository, ApplicationSessionRepository applicationSessionRepository, ParticipantJoinRepository participantJoinRepository) {
+        this.redisTemplate = redisTemplateFactory.getTemplate(ApplicationEntity.class);
+        this.applicationRepository = applicationRepository;
+        this.applicationSessionRepository = applicationSessionRepository;
+        this.participantJoinRepository = participantJoinRepository;
+    }
+
+    public Mono<Void> startLive(String apiKey) {
+        return applicationRepository.findByApiKey(apiKey)
+                .switchIfEmpty(Mono.error(new RestApiException(ApplicationErrorCode.APPLICATION_NOT_FOUND)))
+                .flatMap(application -> {
+                    boolean isOff = application.getStatus() == Status.PENDING;
+
+                    if (application.getType() == ApplicationType.STREAMING) {
+                        return Mono.error(new RestApiException(ApplicationErrorCode.APPLICATION_NOT_SUPPORTED));
+                    }
+                    if (isOff) {
+                        return createApplicationSession(application);
+                    }
+
+                    return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
+                });
+    }
+
+    public Mono<Void> endLive(String apiKey) {
+        return applicationRepository.findByApiKey(apiKey)
+                .switchIfEmpty(Mono.error(new RestApiException(ApplicationErrorCode.APPLICATION_NOT_FOUND)))
+                .flatMap(application -> {
+                    boolean isOn = application.getStatus() == Status.USE;
+
+                    if (application.getType() == ApplicationType.STREAMING) {
+                        return Mono.error(new RestApiException(ApplicationErrorCode.APPLICATION_NOT_SUPPORTED));
+                    }
+                    if (isOn) {
+                        return deleteApplicationSession(application);
+                    }
+
+                    return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
+                });
+    }
+
+    private Mono<Void> createApplicationSession(ApplicationEntity application) {
+        ApplicationSessionEntity applicationSessionEntity = ApplicationSessionEntity.builder()
+                .applicationId(application.getId())
+                .build();
+
+        return applicationSessionRepository.save(applicationSessionEntity)
+                .then(Mono.defer(() -> {
+                    application.setStatus(Status.USE);
+                    return applicationRepository.save(application).then();
+                }));
+    }
+
+    private Mono<Void> deleteApplicationSession(ApplicationEntity application) {
+        return applicationSessionRepository.findTopByApplicationIdOrderByCreatedAtDesc(application.getId())
+                .switchIfEmpty(Mono.error(new RestApiException(ApplicationSessionErrorCode.APPLICATION_SESSION_NOT_FOUND)))
+                .flatMap(applicationSession -> {
+                    applicationSession.setDeletedAt(LocalDateTime.now());
+                    return applicationSessionRepository.save(applicationSession);
+                })
+                .flatMap(applicationSession -> participantJoinRepository.updateAllParticipantJoinsBySessionId(applicationSession.getId()))
+                .then(Mono.defer(() -> {
+                    application.setStatus(Status.PENDING);
+                    return applicationRepository.save(application).then();
+                }));
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/participant/domain/dto/ParticipantDto.java
+++ b/src/main/java/com/instream/tenant/domain/participant/domain/dto/ParticipantDto.java
@@ -1,0 +1,28 @@
+package com.instream.tenant.domain.participant.domain.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public record ParticipantDto(
+        @NotBlank
+        String participantId,
+
+        @NotBlank
+        @JsonIgnore
+        String tenantId,
+
+        @NotBlank
+        String nickname,
+
+        String profileImgUrl,
+
+        LocalDateTime createdAt
+) {
+        @Builder
+        public ParticipantDto {
+
+        }
+}

--- a/src/main/java/com/instream/tenant/domain/participant/domain/dto/ParticipantDto.java
+++ b/src/main/java/com/instream/tenant/domain/participant/domain/dto/ParticipantDto.java
@@ -5,14 +5,15 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record ParticipantDto(
         @NotBlank
-        String participantId,
+        String id,
 
         @NotBlank
         @JsonIgnore
-        String tenantId,
+        UUID tenantId,
 
         @NotBlank
         String nickname,

--- a/src/main/java/com/instream/tenant/domain/participant/domain/dto/ParticipantJoinDto.java
+++ b/src/main/java/com/instream/tenant/domain/participant/domain/dto/ParticipantJoinDto.java
@@ -1,0 +1,23 @@
+package com.instream.tenant.domain.participant.domain.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ParticipantJoinDto(
+        @NotNull
+        UUID id,
+
+        LocalDateTime createdAt,
+
+        LocalDateTime updatedAt,
+
+        ParticipantDto participant
+) {
+        @Builder
+        public ParticipantJoinDto {
+
+        }
+}

--- a/src/main/java/com/instream/tenant/domain/participant/domain/entity/ParticipantEntity.java
+++ b/src/main/java/com/instream/tenant/domain/participant/domain/entity/ParticipantEntity.java
@@ -1,0 +1,45 @@
+package com.instream.tenant.domain.participant.domain.entity;
+
+import com.instream.tenant.domain.application.infra.enums.ApplicationType;
+import com.instream.tenant.domain.common.infra.enums.Status;
+import com.instream.tenant.domain.host.domain.entity.TenantEntity;
+import com.instream.tenant.domain.redis.domain.entity.RedisEntity;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Table(name = "PARTICIPANTS")
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ParticipantEntity implements RedisEntity {
+    @Id
+    @Column(value = "participant_id")
+    private String id;
+
+    private UUID tenantId;
+
+    @NotBlank
+    private String nickname;
+
+    private String profileImgUrl;
+
+    private Status status;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @Override
+    public String genRedisKey() {
+        return getClass().getSimpleName() + "_" + id;
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/participant/domain/entity/ParticipantEntity.java
+++ b/src/main/java/com/instream/tenant/domain/participant/domain/entity/ParticipantEntity.java
@@ -1,8 +1,6 @@
 package com.instream.tenant.domain.participant.domain.entity;
 
-import com.instream.tenant.domain.application.infra.enums.ApplicationType;
 import com.instream.tenant.domain.common.infra.enums.Status;
-import com.instream.tenant.domain.host.domain.entity.TenantEntity;
 import com.instream.tenant.domain.redis.domain.entity.RedisEntity;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;

--- a/src/main/java/com/instream/tenant/domain/participant/domain/entity/ParticipantJoinEntity.java
+++ b/src/main/java/com/instream/tenant/domain/participant/domain/entity/ParticipantJoinEntity.java
@@ -1,8 +1,6 @@
 package com.instream.tenant.domain.participant.domain.entity;
 
-import com.instream.tenant.domain.common.infra.enums.Status;
 import com.instream.tenant.domain.redis.domain.entity.RedisEntity;
-import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
@@ -27,7 +25,7 @@ public class ParticipantJoinEntity implements RedisEntity {
 
     private UUID tenantId;
 
-    private UUID sessionId;
+    private UUID applicationSessionId;
 
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/instream/tenant/domain/participant/domain/entity/ParticipantJoinEntity.java
+++ b/src/main/java/com/instream/tenant/domain/participant/domain/entity/ParticipantJoinEntity.java
@@ -23,7 +23,7 @@ public class ParticipantJoinEntity implements RedisEntity {
     @Column(value = "participant_join_id")
     private UUID id;
 
-    private UUID participantId;
+    private String participantId;
 
     private UUID tenantId;
 

--- a/src/main/java/com/instream/tenant/domain/participant/domain/entity/ParticipantJoinEntity.java
+++ b/src/main/java/com/instream/tenant/domain/participant/domain/entity/ParticipantJoinEntity.java
@@ -1,0 +1,40 @@
+package com.instream.tenant.domain.participant.domain.entity;
+
+import com.instream.tenant.domain.common.infra.enums.Status;
+import com.instream.tenant.domain.redis.domain.entity.RedisEntity;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Table(name = "PARTICIPANT_JOINS")
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ParticipantJoinEntity implements RedisEntity {
+    @Id
+    @Column(value = "participant_join_id")
+    private UUID id;
+
+    private UUID participantId;
+
+    private UUID tenantId;
+
+    private UUID sessionId;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @Override
+    public String genRedisKey() {
+        return getClass().getSimpleName() + "_" + id;
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/participant/domain/request/EnterToApplicationParticipantRequest.java
+++ b/src/main/java/com/instream/tenant/domain/participant/domain/request/EnterToApplicationParticipantRequest.java
@@ -1,0 +1,17 @@
+package com.instream.tenant.domain.participant.domain.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record EnterToApplicationParticipantRequest (
+        @NotNull
+        UUID applicationSessionId,
+
+        @NotBlank
+        String nickname,
+
+        String profileImgUrl
+) {
+}

--- a/src/main/java/com/instream/tenant/domain/participant/domain/request/LeaveFromApplicationParticipantRequest.java
+++ b/src/main/java/com/instream/tenant/domain/participant/domain/request/LeaveFromApplicationParticipantRequest.java
@@ -1,0 +1,11 @@
+package com.instream.tenant.domain.participant.domain.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record LeaveFromApplicationParticipantRequest(
+        @NotNull
+        UUID applicationSessionId
+) {
+}

--- a/src/main/java/com/instream/tenant/domain/participant/handler/ParticipantHandler.java
+++ b/src/main/java/com/instream/tenant/domain/participant/handler/ParticipantHandler.java
@@ -32,7 +32,7 @@ public class ParticipantHandler {
             hostId = UUID.fromString(request.pathVariable("hostId"));
             participantId = request.pathVariable("participantId");
         } catch (IllegalArgumentException illegalArgumentException) {
-            throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
+            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
         }
 
         return request.bodyToMono(EnterToApplicationParticipantRequest.class)
@@ -50,7 +50,7 @@ public class ParticipantHandler {
             hostId = UUID.fromString(request.pathVariable("hostId"));
             participantId = request.pathVariable("participantId");
         } catch (IllegalArgumentException illegalArgumentException) {
-            throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
+            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
         }
 
         return request.bodyToMono(LeaveFromApplicationParticipantRequest.class)

--- a/src/main/java/com/instream/tenant/domain/participant/handler/ParticipantHandler.java
+++ b/src/main/java/com/instream/tenant/domain/participant/handler/ParticipantHandler.java
@@ -1,0 +1,61 @@
+package com.instream.tenant.domain.participant.handler;
+
+import com.instream.tenant.domain.application.domain.request.ApplicationCreateRequest;
+import com.instream.tenant.domain.error.infra.enums.CommonHttpErrorCode;
+import com.instream.tenant.domain.error.model.exception.RestApiException;
+import com.instream.tenant.domain.participant.domain.request.EnterToApplicationParticipantRequest;
+import com.instream.tenant.domain.participant.domain.request.LeaveFromApplicationParticipantRequest;
+import com.instream.tenant.domain.participant.service.ParticipantService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Component
+public class ParticipantHandler {
+    private final ParticipantService participantService;
+
+    @Autowired
+    public ParticipantHandler(ParticipantService participantService) {
+        this.participantService = participantService;
+    }
+
+    public Mono<ServerResponse> enterToApplication(ServerRequest request) {
+        String apiKey = null;
+        UUID hostId;
+        String applicationId;
+
+        try {
+            hostId = UUID.fromString(request.pathVariable("hostId"));
+            applicationId = request.pathVariable("applicationId");
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
+        }
+
+        return request.bodyToMono(EnterToApplicationParticipantRequest.class)
+                .onErrorMap(throwable -> new RestApiException(CommonHttpErrorCode.BAD_REQUEST))
+                .flatMap(enterToApplicationParticipantRequest -> participantService.enterToApplication(apiKey, hostId, applicationId, enterToApplicationParticipantRequest))
+                .flatMap(participantJoinDto -> ServerResponse.ok().bodyValue(participantJoinDto));
+    }
+
+    public Mono leaveFromApplication(ServerRequest request) {
+        String apiKey = null;
+        UUID hostId;
+        String applicationId;
+
+        try {
+            hostId = UUID.fromString(request.pathVariable("hostId"));
+            applicationId = request.pathVariable("applicationId");
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
+        }
+
+        return request.bodyToMono(LeaveFromApplicationParticipantRequest.class)
+                .onErrorMap(throwable -> new RestApiException(CommonHttpErrorCode.BAD_REQUEST))
+                .flatMap(applicationSessionId -> participantService.leaveFromApplication(apiKey, hostId, applicationId, applicationSessionId))
+                .flatMap(participantJoinDto -> ServerResponse.ok().bodyValue(participantJoinDto));
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/participant/handler/ParticipantHandler.java
+++ b/src/main/java/com/instream/tenant/domain/participant/handler/ParticipantHandler.java
@@ -26,36 +26,36 @@ public class ParticipantHandler {
     public Mono<ServerResponse> enterToApplication(ServerRequest request) {
         String apiKey = null;
         UUID hostId;
-        String applicationId;
+        String participantId;
 
         try {
             hostId = UUID.fromString(request.pathVariable("hostId"));
-            applicationId = request.pathVariable("applicationId");
+            participantId = request.pathVariable("participantId");
         } catch (IllegalArgumentException illegalArgumentException) {
             throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
         }
 
         return request.bodyToMono(EnterToApplicationParticipantRequest.class)
                 .onErrorMap(throwable -> new RestApiException(CommonHttpErrorCode.BAD_REQUEST))
-                .flatMap(enterToApplicationParticipantRequest -> participantService.enterToApplication(apiKey, hostId, applicationId, enterToApplicationParticipantRequest))
+                .flatMap(enterToApplicationParticipantRequest -> participantService.enterToApplication(apiKey, hostId, participantId, enterToApplicationParticipantRequest))
                 .flatMap(participantJoinDto -> ServerResponse.ok().bodyValue(participantJoinDto));
     }
 
     public Mono leaveFromApplication(ServerRequest request) {
         String apiKey = null;
         UUID hostId;
-        String applicationId;
+        String participantId;
 
         try {
             hostId = UUID.fromString(request.pathVariable("hostId"));
-            applicationId = request.pathVariable("applicationId");
+            participantId = request.pathVariable("participantId");
         } catch (IllegalArgumentException illegalArgumentException) {
             throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
         }
 
         return request.bodyToMono(LeaveFromApplicationParticipantRequest.class)
                 .onErrorMap(throwable -> new RestApiException(CommonHttpErrorCode.BAD_REQUEST))
-                .flatMap(applicationSessionId -> participantService.leaveFromApplication(apiKey, hostId, applicationId, applicationSessionId))
+                .flatMap(applicationSessionId -> participantService.leaveFromApplication(apiKey, hostId, participantId, applicationSessionId))
                 .flatMap(participantJoinDto -> ServerResponse.ok().bodyValue(participantJoinDto));
     }
 }

--- a/src/main/java/com/instream/tenant/domain/participant/infra/enums/ParticipantErrorCode.java
+++ b/src/main/java/com/instream/tenant/domain/participant/infra/enums/ParticipantErrorCode.java
@@ -1,0 +1,29 @@
+package com.instream.tenant.domain.participant.infra.enums;
+
+import com.instream.tenant.domain.error.infra.enums.HttpErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ParticipantErrorCode implements HttpErrorCode {
+    PARTICIPANT_NOT_FOUND("참가자를 찾지 못 했습니다.", HttpStatus.NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ParticipantErrorCode(String message, HttpStatus httpStatus) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/participant/infra/enums/ParticipantJoinErrorCode.java
+++ b/src/main/java/com/instream/tenant/domain/participant/infra/enums/ParticipantJoinErrorCode.java
@@ -1,0 +1,29 @@
+package com.instream.tenant.domain.participant.infra.enums;
+
+import com.instream.tenant.domain.error.infra.enums.HttpErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ParticipantJoinErrorCode implements HttpErrorCode {
+    PARTICIPANT_JOIN_NOT_FOUND("참가자 참여 기록을 찾지 못 했습니다.", HttpStatus.NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ParticipantJoinErrorCode(String message, HttpStatus httpStatus) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/participant/repository/InsertParticipantRepository.java
+++ b/src/main/java/com/instream/tenant/domain/participant/repository/InsertParticipantRepository.java
@@ -1,0 +1,8 @@
+package com.instream.tenant.domain.participant.repository;
+
+import com.instream.tenant.domain.participant.domain.entity.ParticipantEntity;
+import reactor.core.publisher.Mono;
+
+public interface InsertParticipantRepository {
+    Mono<ParticipantEntity> insert(ParticipantEntity participant);
+}

--- a/src/main/java/com/instream/tenant/domain/participant/repository/InsertParticipantRepositoryImpl.java
+++ b/src/main/java/com/instream/tenant/domain/participant/repository/InsertParticipantRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.instream.tenant.domain.participant.repository;
+
+import com.instream.tenant.domain.participant.domain.entity.ParticipantEntity;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import reactor.core.publisher.Mono;
+
+public class InsertParticipantRepositoryImpl implements InsertParticipantRepository {
+
+    private final R2dbcEntityTemplate template;
+
+    public InsertParticipantRepositoryImpl(R2dbcEntityTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public Mono<ParticipantEntity> insert(ParticipantEntity participant) {
+        return template.insert(ParticipantEntity.class).using(participant).thenReturn(participant);
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantJoinRepository.java
+++ b/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantJoinRepository.java
@@ -10,8 +10,8 @@ import reactor.core.publisher.Mono;
 import java.util.UUID;
 
 public interface ParticipantJoinRepository extends QuerydslR2dbcRepository<ParticipantJoinEntity, UUID> {
-    Mono<ParticipantJoinEntity> findByTenantIdAndParticipantIdAndSessionId(UUID tenantId, String participantId, UUID sessionId);
+    Mono<ParticipantJoinEntity> findByTenantIdAndParticipantIdAndApplicationSessionId(UUID tenantId, String participantId, UUID applicationSessionId);
 
-    @Query("UPDATE participant_join SET updated_at = NOW() WHERE application_session_id = :applicationSessionId")
+    @Query("UPDATE participant_joins SET updated_at = NOW() WHERE application_session_id = :applicationSessionId")
     Mono<Integer> updateAllParticipantJoinsBySessionId(@Param("applicationSessionId") UUID applicationSessionId);
 }

--- a/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantJoinRepository.java
+++ b/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantJoinRepository.java
@@ -2,8 +2,10 @@ package com.instream.tenant.domain.participant.repository;
 
 import com.infobip.spring.data.r2dbc.QuerydslR2dbcRepository;
 import com.instream.tenant.domain.participant.domain.entity.ParticipantJoinEntity;
+import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 public interface ParticipantJoinRepository extends QuerydslR2dbcRepository<ParticipantJoinEntity, UUID> {
+    Mono<ParticipantJoinEntity> findByTenantIdAndParticipantIdAndSessionId(UUID tenantId, String participantId, UUID sessionId);
 }

--- a/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantJoinRepository.java
+++ b/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantJoinRepository.java
@@ -2,10 +2,16 @@ package com.instream.tenant.domain.participant.repository;
 
 import com.infobip.spring.data.r2dbc.QuerydslR2dbcRepository;
 import com.instream.tenant.domain.participant.domain.entity.ParticipantJoinEntity;
+import org.springframework.data.r2dbc.repository.Modifying;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.query.Param;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 public interface ParticipantJoinRepository extends QuerydslR2dbcRepository<ParticipantJoinEntity, UUID> {
     Mono<ParticipantJoinEntity> findByTenantIdAndParticipantIdAndSessionId(UUID tenantId, String participantId, UUID sessionId);
+
+    @Query("UPDATE participant_join SET updated_at = NOW() WHERE application_session_id = :applicationSessionId")
+    Mono<Integer> updateAllParticipantJoinsBySessionId(@Param("applicationSessionId") UUID applicationSessionId);
 }

--- a/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantJoinRepository.java
+++ b/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantJoinRepository.java
@@ -1,0 +1,9 @@
+package com.instream.tenant.domain.participant.repository;
+
+import com.infobip.spring.data.r2dbc.QuerydslR2dbcRepository;
+import com.instream.tenant.domain.participant.domain.entity.ParticipantJoinEntity;
+
+import java.util.UUID;
+
+public interface ParticipantJoinRepository extends QuerydslR2dbcRepository<ParticipantJoinEntity, UUID> {
+}

--- a/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantRepository.java
@@ -5,5 +5,5 @@ import com.instream.tenant.domain.participant.domain.entity.ParticipantEntity;
 
 import java.util.UUID;
 
-public interface ParticipantRepository extends QuerydslR2dbcRepository<ParticipantEntity, UUID> {
+public interface ParticipantRepository extends QuerydslR2dbcRepository<ParticipantEntity, String> {
 }

--- a/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantRepository.java
@@ -5,5 +5,5 @@ import com.instream.tenant.domain.participant.domain.entity.ParticipantEntity;
 
 import java.util.UUID;
 
-public interface ParticipantRepository extends QuerydslR2dbcRepository<ParticipantEntity, String> {
+public interface ParticipantRepository extends QuerydslR2dbcRepository<ParticipantEntity, String>, InsertParticipantRepository {
 }

--- a/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/instream/tenant/domain/participant/repository/ParticipantRepository.java
@@ -1,0 +1,9 @@
+package com.instream.tenant.domain.participant.repository;
+
+import com.infobip.spring.data.r2dbc.QuerydslR2dbcRepository;
+import com.instream.tenant.domain.participant.domain.entity.ParticipantEntity;
+
+import java.util.UUID;
+
+public interface ParticipantRepository extends QuerydslR2dbcRepository<ParticipantEntity, UUID> {
+}

--- a/src/main/java/com/instream/tenant/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/instream/tenant/domain/participant/service/ParticipantService.java
@@ -3,8 +3,8 @@ package com.instream.tenant.domain.participant.service;
 import com.instream.tenant.domain.application.infra.enums.ApplicationSessionErrorCode;
 import com.instream.tenant.domain.application.repository.ApplicationSessionRepository;
 import com.instream.tenant.domain.error.model.exception.RestApiException;
-import com.instream.tenant.domain.host.infra.enums.TenantErrorCode;
-import com.instream.tenant.domain.host.repository.TenantRepository;
+import com.instream.tenant.domain.tenant.infra.enums.TenantErrorCode;
+import com.instream.tenant.domain.tenant.repository.TenantRepository;
 import com.instream.tenant.domain.participant.domain.dto.ParticipantDto;
 import com.instream.tenant.domain.participant.domain.dto.ParticipantJoinDto;
 import com.instream.tenant.domain.participant.domain.entity.ParticipantEntity;
@@ -20,7 +20,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @Service

--- a/src/main/java/com/instream/tenant/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/instream/tenant/domain/participant/service/ParticipantService.java
@@ -1,0 +1,41 @@
+package com.instream.tenant.domain.participant.service;
+
+import com.instream.tenant.domain.participant.domain.dto.ParticipantJoinDto;
+import com.instream.tenant.domain.participant.domain.request.EnterToApplicationParticipantRequest;
+import com.instream.tenant.domain.participant.repository.ParticipantJoinRepository;
+import com.instream.tenant.domain.participant.repository.ParticipantRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class ParticipantService {
+    private final ParticipantRepository participantRepository;
+
+    private final ParticipantJoinRepository participantJoinRepository;
+
+    @Autowired
+    public ParticipantService(ParticipantRepository participantRepository, ParticipantJoinRepository participantJoinRepository) {
+        this.participantRepository = participantRepository;
+        this.participantJoinRepository = participantJoinRepository;
+    }
+
+    Mono<ParticipantJoinDto> enterToApplication(String apiKey, String hostId, String participantId, EnterToApplicationParticipantRequest enterToApplicationParticipantRequest) {
+        // TODO: 참가자 ID 암호화 로직 결정
+        // TODO: participantId로 사용된 로직 추후 encryptedParticipantId로 수정
+
+        return Mono.just(ParticipantJoinDto.builder()
+                .build());
+    }
+
+    Mono<ParticipantJoinDto> leaveFromApplication(String apiKey, String hostId, String participantId, UUID applicationSessionId) {
+        // TODO: 참가자 ID 암호화 로직 결정
+        // TODO: participantId로 사용된 로직 추후 encryptedParticipantId로 수정
+        return Mono.just(ParticipantJoinDto.builder()
+                .build());
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/instream/tenant/domain/participant/service/ParticipantService.java
@@ -10,6 +10,7 @@ import com.instream.tenant.domain.participant.domain.dto.ParticipantJoinDto;
 import com.instream.tenant.domain.participant.domain.entity.ParticipantEntity;
 import com.instream.tenant.domain.participant.domain.entity.ParticipantJoinEntity;
 import com.instream.tenant.domain.participant.domain.request.EnterToApplicationParticipantRequest;
+import com.instream.tenant.domain.participant.domain.request.LeaveFromApplicationParticipantRequest;
 import com.instream.tenant.domain.participant.infra.enums.ParticipantErrorCode;
 import com.instream.tenant.domain.participant.infra.enums.ParticipantJoinErrorCode;
 import com.instream.tenant.domain.participant.repository.ParticipantJoinRepository;
@@ -41,7 +42,7 @@ public class ParticipantService {
         this.participantJoinRepository = participantJoinRepository;
     }
 
-    Mono<ParticipantJoinDto> enterToApplication(String apiKey, UUID tenantId, String participantId, EnterToApplicationParticipantRequest enterToApplicationParticipantRequest) {
+    public Mono<ParticipantJoinDto> enterToApplication(String apiKey, UUID tenantId, String participantId, EnterToApplicationParticipantRequest enterToApplicationParticipantRequest) {
         // TODO: 참가자 ID 암호화 로직 결정
         // TODO: participantId로 사용된 로직 추후 encryptedParticipantId로 수정
         // TODO: 현재 Reactive chain이 너무 길어지는 문제 발생. 검증 로직은 Validator로 구현하고, ReactiveValidator는 Validator랑 composite하는 형태로 구현하기
@@ -85,7 +86,7 @@ public class ParticipantService {
         });
     }
 
-    Mono<ParticipantJoinDto> leaveFromApplication(String apiKey, UUID tenantId, String participantId, UUID applicationSessionId) {
+    public Mono<ParticipantJoinDto> leaveFromApplication(String apiKey, UUID tenantId, String participantId, LeaveFromApplicationParticipantRequest leaveFromApplicationParticipantRequest) {
         // TODO: 참가자 ID 암호화 로직 결정
         // TODO: participantId로 사용된 로직 추후 encryptedParticipantId로 수정
         // TODO: 현재 Reactive chain이 너무 길어지는 문제 발생. 검증 로직은 Validator로 구현하고, ReactiveValidator는 Validator랑 composite하는 형태로 구현하기
@@ -96,7 +97,7 @@ public class ParticipantService {
                 return Mono.error(new RestApiException(TenantErrorCode.TENANT_NOT_FOUND));
             }
 
-            return applicationSessionRepository.findById(applicationSessionId)
+            return applicationSessionRepository.findById(leaveFromApplicationParticipantRequest.applicationSessionId())
                     .switchIfEmpty(Mono.error(new RestApiException(ApplicationSessionErrorCode.APPLICATION_SESSION_NOT_FOUND)))
                     .flatMap(applicationSession -> {
 
@@ -107,7 +108,7 @@ public class ParticipantService {
 
                         Mono<ParticipantEntity> participantEntityMono = participantRepository.findById(participantId)
                                 .switchIfEmpty(Mono.error(new RestApiException(ParticipantErrorCode.PARTICIPANT_NOT_FOUND)));
-                        Mono<ParticipantJoinEntity> participantJoinEntityMono = participantJoinRepository.findByTenantIdAndParticipantIdAndSessionId(tenantId, participantId, applicationSessionId)
+                        Mono<ParticipantJoinEntity> participantJoinEntityMono = participantJoinRepository.findByTenantIdAndParticipantIdAndSessionId(tenantId, participantId, leaveFromApplicationParticipantRequest.applicationSessionId())
                                 .switchIfEmpty(Mono.error(new RestApiException(ParticipantJoinErrorCode.PARTICIPANT_JOIN_NOT_FOUND)));
 
                         return Mono.zip(participantEntityMono, participantJoinEntityMono, (participant, participantJoin) -> ParticipantJoinDto.builder()

--- a/src/main/java/com/instream/tenant/domain/tenant/config/HostApplicationRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/config/HostApplicationRouterConfig.java
@@ -1,4 +1,4 @@
-package com.instream.tenant.domain.host.config;
+package com.instream.tenant.domain.tenant.config;
 
 import com.instream.tenant.domain.application.domain.dto.ApplicationDto;
 import com.instream.tenant.domain.application.domain.request.ApplicationCreateRequest;

--- a/src/main/java/com/instream/tenant/domain/tenant/config/HostParticipantRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/config/HostParticipantRouterConfig.java
@@ -1,0 +1,66 @@
+package com.instream.tenant.domain.tenant.config;
+
+import com.instream.tenant.domain.application.domain.dto.ApplicationDto;
+import com.instream.tenant.domain.application.domain.request.ApplicationCreateRequest;
+import com.instream.tenant.domain.application.domain.request.ApplicationSearchPaginationOptionRequest;
+import com.instream.tenant.domain.application.domain.response.ApplicationCreateResponse;
+import com.instream.tenant.domain.application.handler.ApplicationHandler;
+import com.instream.tenant.domain.participant.domain.dto.ParticipantJoinDto;
+import com.instream.tenant.domain.participant.domain.request.EnterToApplicationParticipantRequest;
+import com.instream.tenant.domain.participant.domain.request.LeaveFromApplicationParticipantRequest;
+import com.instream.tenant.domain.participant.handler.ParticipantHandler;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.springdoc.core.fn.builders.apiresponse.Builder.responseBuilder;
+import static org.springdoc.core.fn.builders.parameter.Builder.parameterBuilder;
+import static org.springdoc.core.fn.builders.requestbody.Builder.requestBodyBuilder;
+import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
+
+
+@Configuration
+public class HostParticipantRouterConfig {
+    @Bean
+    public RouterFunction<ServerResponse> v1HostParticipantRoutes(ParticipantHandler participantHandler) {
+        return route().nest(RequestPredicates.path("/v1/hosts/{hostId}/participants"),
+                builder -> {
+                    builder.add(enterToApplication(participantHandler));
+                    builder.add(leaveFromApplication(participantHandler));;
+                },
+                ops -> ops.operationId("123")
+        ).build();
+    }
+
+    private RouterFunction<ServerResponse> enterToApplication(ParticipantHandler participantHandler) {
+        return route()
+                .PUT(
+                        "/{participantId}/enter",
+                        participantHandler::enterToApplication,
+                        ops -> ops.operationId("123")
+                                .parameter(parameterBuilder().name("hostId").in(ParameterIn.PATH).required(true).example("80bd6328-76a7-11ee-b720-0242ac130003"))
+                                .parameter(parameterBuilder().name("participantId").in(ParameterIn.PATH).required(true).example("123abc"))
+                                .requestBody(requestBodyBuilder().implementation(EnterToApplicationParticipantRequest.class).required(true))
+                                .response(responseBuilder().responseCode(HttpStatus.OK.name()).implementation(ParticipantJoinDto.class))
+                )
+                .build();
+    }
+
+    private RouterFunction<ServerResponse> leaveFromApplication(ParticipantHandler participantHandler) {
+        return route()
+                .PATCH(
+                        "/{participantId}/leave",
+                        participantHandler::leaveFromApplication,
+                        ops -> ops.operationId("123")
+                                .parameter(parameterBuilder().name("hostId").in(ParameterIn.PATH).required(true).example("80bd6328-76a7-11ee-b720-0242ac130003"))
+                                .parameter(parameterBuilder().name("participantId").in(ParameterIn.PATH).required(true).example("123abc"))
+                                .requestBody(requestBodyBuilder().implementation(LeaveFromApplicationParticipantRequest.class).required(true))
+                                .response(responseBuilder().responseCode(HttpStatus.OK.name()).implementation(ParticipantJoinDto.class))
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/instream/tenant/domain/tenant/config/HostRouterConfig.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/config/HostRouterConfig.java
@@ -1,17 +1,15 @@
-package com.instream.tenant.domain.host.config;
+package com.instream.tenant.domain.tenant.config;
 
-import com.instream.tenant.domain.host.domain.dto.TenantDto;
-import com.instream.tenant.domain.host.domain.request.TenantCreateRequest;
-import com.instream.tenant.domain.host.domain.request.TenantSignInRequest;
-import com.instream.tenant.domain.host.handler.HostHandler;
+import com.instream.tenant.domain.tenant.domain.dto.TenantDto;
+import com.instream.tenant.domain.tenant.domain.request.TenantCreateRequest;
+import com.instream.tenant.domain.tenant.domain.request.TenantSignInRequest;
+import com.instream.tenant.domain.tenant.handler.HostHandler;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
-
-import java.lang.reflect.Type;
 
 import static org.springdoc.core.fn.builders.apiresponse.Builder.responseBuilder;
 import static org.springdoc.core.fn.builders.parameter.Builder.parameterBuilder;

--- a/src/main/java/com/instream/tenant/domain/tenant/domain/dto/TenantDto.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/domain/dto/TenantDto.java
@@ -1,4 +1,4 @@
-package com.instream.tenant.domain.host.domain.dto;
+package com.instream.tenant.domain.tenant.domain.dto;
 
 import com.instream.tenant.domain.common.infra.enums.Status;
 import lombok.Builder;

--- a/src/main/java/com/instream/tenant/domain/tenant/domain/entity/TenantEntity.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/domain/entity/TenantEntity.java
@@ -1,4 +1,4 @@
-package com.instream.tenant.domain.host.domain.entity;
+package com.instream.tenant.domain.tenant.domain.entity;
 
 import com.instream.tenant.domain.common.infra.enums.Status;
 import com.instream.tenant.domain.redis.domain.entity.RedisEntity;

--- a/src/main/java/com/instream/tenant/domain/tenant/domain/request/TenantCreateRequest.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/domain/request/TenantCreateRequest.java
@@ -1,4 +1,4 @@
-package com.instream.tenant.domain.host.domain.request;
+package com.instream.tenant.domain.tenant.domain.request;
 
 public record TenantCreateRequest(
         String account,

--- a/src/main/java/com/instream/tenant/domain/tenant/domain/request/TenantSignInRequest.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/domain/request/TenantSignInRequest.java
@@ -1,4 +1,4 @@
-package com.instream.tenant.domain.host.domain.request;
+package com.instream.tenant.domain.tenant.domain.request;
 
 public record TenantSignInRequest(
         String account,

--- a/src/main/java/com/instream/tenant/domain/tenant/handler/HostHandler.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/handler/HostHandler.java
@@ -1,10 +1,10 @@
-package com.instream.tenant.domain.host.handler;
+package com.instream.tenant.domain.tenant.handler;
 
 import com.instream.tenant.domain.error.model.exception.RestApiException;
 import com.instream.tenant.domain.error.infra.enums.CommonHttpErrorCode;
-import com.instream.tenant.domain.host.domain.request.TenantCreateRequest;
-import com.instream.tenant.domain.host.domain.request.TenantSignInRequest;
-import com.instream.tenant.domain.host.service.TenantService;
+import com.instream.tenant.domain.tenant.domain.request.TenantCreateRequest;
+import com.instream.tenant.domain.tenant.domain.request.TenantSignInRequest;
+import com.instream.tenant.domain.tenant.service.TenantService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;

--- a/src/main/java/com/instream/tenant/domain/tenant/handler/HostHandler.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/handler/HostHandler.java
@@ -29,7 +29,7 @@ public class HostHandler {
         try {
             hostId = UUID.fromString(request.pathVariable("hostId"));
         } catch (IllegalArgumentException illegalArgumentException) {
-            throw new RestApiException(CommonHttpErrorCode.BAD_REQUEST);
+            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
         }
 
         return Mono.just(hostId)

--- a/src/main/java/com/instream/tenant/domain/tenant/infra/converter/StatusReadConverter.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/infra/converter/StatusReadConverter.java
@@ -1,4 +1,4 @@
-package com.instream.tenant.domain.host.infra.converter;
+package com.instream.tenant.domain.tenant.infra.converter;
 
 import com.instream.tenant.domain.common.infra.enums.Status;
 import org.springframework.core.convert.converter.Converter;

--- a/src/main/java/com/instream/tenant/domain/tenant/infra/converter/StatusWriteConverter.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/infra/converter/StatusWriteConverter.java
@@ -1,4 +1,4 @@
-package com.instream.tenant.domain.host.infra.converter;
+package com.instream.tenant.domain.tenant.infra.converter;
 
 import com.instream.tenant.domain.common.infra.enums.Status;
 import org.springframework.core.convert.converter.Converter;

--- a/src/main/java/com/instream/tenant/domain/tenant/infra/enums/TenantErrorCode.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/infra/enums/TenantErrorCode.java
@@ -1,7 +1,6 @@
-package com.instream.tenant.domain.host.infra.enums;
+package com.instream.tenant.domain.tenant.infra.enums;
 
 import com.instream.tenant.domain.error.infra.enums.HttpErrorCode;
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 public enum TenantErrorCode implements HttpErrorCode {

--- a/src/main/java/com/instream/tenant/domain/tenant/repository/TenantRepository.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/repository/TenantRepository.java
@@ -1,6 +1,6 @@
-package com.instream.tenant.domain.host.repository;
+package com.instream.tenant.domain.tenant.repository;
 
-import com.instream.tenant.domain.host.domain.entity.TenantEntity;
+import com.instream.tenant.domain.tenant.domain.entity.TenantEntity;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Mono;
 

--- a/src/main/java/com/instream/tenant/domain/tenant/service/TenantService.java
+++ b/src/main/java/com/instream/tenant/domain/tenant/service/TenantService.java
@@ -1,13 +1,13 @@
-package com.instream.tenant.domain.host.service;
+package com.instream.tenant.domain.tenant.service;
 
 import com.instream.tenant.domain.common.infra.enums.Status;
 import com.instream.tenant.domain.error.model.exception.RestApiException;
-import com.instream.tenant.domain.host.domain.dto.TenantDto;
-import com.instream.tenant.domain.host.domain.entity.TenantEntity;
-import com.instream.tenant.domain.host.domain.request.TenantCreateRequest;
-import com.instream.tenant.domain.host.domain.request.TenantSignInRequest;
-import com.instream.tenant.domain.host.infra.enums.TenantErrorCode;
-import com.instream.tenant.domain.host.repository.TenantRepository;
+import com.instream.tenant.domain.tenant.domain.dto.TenantDto;
+import com.instream.tenant.domain.tenant.domain.entity.TenantEntity;
+import com.instream.tenant.domain.tenant.domain.request.TenantCreateRequest;
+import com.instream.tenant.domain.tenant.domain.request.TenantSignInRequest;
+import com.instream.tenant.domain.tenant.infra.enums.TenantErrorCode;
+import com.instream.tenant.domain.tenant.repository.TenantRepository;
 import com.instream.tenant.domain.redis.model.factory.ReactiveRedisTemplateFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- <PUT> /v1/hosts/:hostId/participants/:participantId/enter 구현
    - Participant entity를 insert하기 위한 InsertParticipantRepository interface 구현
- <PATCH> /v1/hosts/:hostId/participants/:participantId/leave 구현

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- insert or update (save method) 이후 entity에 변경사항이 반영 안 됩니다. 특히 createdAt, updatedAt과 같은 DB 서버에 묶인 default value가 반영 안 됩니다. 따라서 insert or update 이후 select 쿼리를 하나 추가했습니다.
    - default value를 DB 서버에 묶지 말고 어플리케이션에서 관리하는 것은 어떤지 의논이 필요합니다. 속도 vs 안정성 사이 trade-off가 있을 것 같습니다.  
- @GeneratedValue 어노테이션이 붙어 있지 않으면, id가 null이 아닐 땐 save method가 무조건 update 쿼리를 생성합니다. 따라서 id를 비즈니스 로직에 따라 결정해서 insert 해야할 때는 insert method를 구현하셔야 합니다. 구현시 R2dbcEntityTemplate를 권장합니다.

<br/><br/>
