### PR TITLE
<FIX> ApiKey 헤더가 미적용 되어있는 api 수정

### DIFF
--- a/src/main/java/com/instream/tenant/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/instream/tenant/domain/application/service/ApplicationService.java
@@ -83,6 +83,7 @@ public class ApplicationService {
                                 .build())
                         .defaultIfEmpty(ApplicationWithApiKeyDto.builder()
                                 .applicationId(applicationEntity.getId())
+                                .apiKey(applicationEntity.getApiKey())
                                 .type(applicationEntity.getType())
                                 .status(applicationEntity.getStatus())
                                 .createdAt(applicationEntity.getCreatedAt())

--- a/src/main/java/com/instream/tenant/domain/participant/handler/ParticipantHandler.java
+++ b/src/main/java/com/instream/tenant/domain/participant/handler/ParticipantHandler.java
@@ -88,7 +88,7 @@ public class ParticipantHandler {
     }
 
     public Mono<ServerResponse> searchParticipantJoinWithApplicationSession(ServerRequest request) {
-        String apiKey = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
+        String apiKey = request.headers().firstHeader(InstreamHttpHeaders.API_KEY);
 
         if (apiKey == null || apiKey.isEmpty()) {
             return Mono.error(new RestApiException(CommonHttpErrorCode.UNAUTHORIZED));


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- HttpHeaders.AUTHORIZATION 에서 InstreamHttpHeaders.API_KEY 로 수정
- 세션 없을 때도 application api key 주도록 수정

<br/>

### 📘 작업 유형

- 버그 수정

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2

<br/><br/>
